### PR TITLE
feat: experimental Line6 HX Stomp (.hlx) import

### DIFF
--- a/src/app/[locale]/editor/page.tsx
+++ b/src/app/[locale]/editor/page.tsx
@@ -17,6 +17,7 @@ import { FirmwareCompatDialog } from '@/components/FirmwareCompatDialog';
 import { SavePresetDialog } from '@/components/SavePresetDialog';
 import { AddToPlaylistDialog } from '@/components/AddToPlaylistDialog';
 import { SysExCodec } from '@/core/SysExCodec';
+import { convertHLX } from '@/core/HLXConverter';
 import type { GP200Preset } from '@/core/types';
 
 export default function EditorPage() {
@@ -42,6 +43,7 @@ export default function EditorPage() {
   const pedalGridRef = useRef<HTMLDivElement>(null);
   // Track source preset when loaded from gallery (for update vs save-as-new)
   const [sourcePreset, setSourcePreset] = useState<{ id: string; username: string; author: string; style: string; description: string } | null>(null);
+  const [importedFromHLX, setImportedFromHLX] = useState(false);
 
   useEffect(() => {
     fetch('/api/profile')
@@ -96,12 +98,22 @@ export default function EditorPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [midiDevice.currentPreset]);
 
-  const handleFile = useCallback((buffer: Uint8Array, _filename: string) => {
+  const handleFile = useCallback((buffer: Uint8Array, filename: string) => {
     try {
-      const decoder = new PRSTDecoder(buffer);
-      loadPreset(decoder.decode());
+      if (filename.toLowerCase().endsWith('.hlx')) {
+        // HLX import (experimental)
+        const text = new TextDecoder().decode(buffer);
+        const hlx = JSON.parse(text);
+        const converted = convertHLX(hlx);
+        loadPreset(converted);
+        setImportedFromHLX(true);
+      } else {
+        const decoder = new PRSTDecoder(buffer);
+        loadPreset(decoder.decode());
+        setImportedFromHLX(false);
+      }
       setLoadError(null);
-      setSourcePreset(null); // Clear gallery source — this is a local file
+      setSourcePreset(null);
     } catch (err) {
       setLoadError(`${t('loadError')}: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -345,6 +357,14 @@ export default function EditorPage() {
 
   return (
     <div className={`p-8 mx-auto ${viewMode === 'pedals' ? 'max-w-6xl' : 'max-w-2xl'}`}>
+      {/* Experimental HLX import badge */}
+      {importedFromHLX && (
+        <div className="mb-4 px-3 py-1.5 rounded-lg font-mono-display text-[11px] tracking-wider uppercase inline-flex items-center gap-2"
+          style={{ background: 'rgba(168,85,247,0.1)', border: '1px solid rgba(168,85,247,0.3)', color: '#a855f7' }}>
+          EXPERIMENTAL — imported from Line6 HX Stomp (.hlx)
+        </div>
+      )}
+
       {/* Header with patch name + author + slot */}
       <div className="flex items-center gap-4 mb-4 flex-wrap">
         <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -575,7 +595,7 @@ export default function EditorPage() {
           {t('loadFromDisk')}
           <input
             type="file"
-            accept=".prst"
+            accept=".prst,.hlx"
             className="hidden"
             onChange={(e) => {
               const file = e.target.files?.[0];

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -54,11 +54,11 @@ export function FileUpload({ onFile }: FileUploadProps) {
         &#x2191;
       </div>
       <p className="text-lg font-medium" style={{ color: 'var(--text-primary)' }}>{t('uploadCta')}</p>
-      <p className="text-sm mt-2 font-mono-display" style={{ color: 'var(--text-muted)' }}>.prst</p>
+      <p className="text-sm mt-2 font-mono-display" style={{ color: 'var(--text-muted)' }}>.prst / .hlx</p>
       <input
         ref={inputRef}
         type="file"
-        accept=".prst"
+        accept=".prst,.hlx"
         className="hidden"
         onChange={handleChange}
         data-testid="file-input"

--- a/src/core/HLXConverter.ts
+++ b/src/core/HLXConverter.ts
@@ -1,0 +1,271 @@
+/**
+ * HLX → GP200Preset Converter (Experimental)
+ *
+ * Converts Line6 HX Stomp .hlx presets (JSON) to GP-200 .prst format.
+ * Best-effort mapping — different devices, different effects, approximate results.
+ */
+
+import type { GP200Preset, EffectSlot } from './types';
+import { EFFECT_MAP } from './effectNames';
+
+// ── GP-200 module slot order (fixed signal chain) ──────────────────────
+const GP200_MODULES = ['PRE', 'WAH', 'DST', 'AMP', 'NR', 'CAB', 'EQ', 'MOD', 'DLY', 'RVB', 'VOL'] as const;
+
+// ── Default effect per GP-200 module (used when no better match found) ─
+const MODULE_DEFAULTS: Record<string, number> = {
+  PRE: 0,           // COMP
+  WAH: 0x05000001,  // V-Wah
+  DST: 0x03000000,  // Green OD
+  AMP: 0x07000001,  // Tweedy
+  NR:  27,          // Gate 1
+  CAB: 0x0A000000,  // SUP ZEP
+  EQ:  0x01000035,  // Guitar EQ 1
+  MOD: 0x01000029,  // Detune
+  DLY: 0x0B000000,  // Pure
+  RVB: 0x0C000000,  // Room
+  VOL: 0x06000003,  // Volume
+};
+
+// ── HLX model → GP-200 module classification ──────────────────────────
+interface HLXBlock {
+  '@model': string;
+  '@type': number;
+  '@position': number;
+  '@enabled': boolean;
+  '@path'?: number;
+  [key: string]: unknown;
+}
+
+function classifyHLXBlock(block: HLXBlock): string | null {
+  const model = block['@model'] ?? '';
+  const type = block['@type'];
+  const m = model.toLowerCase();
+
+  // Type-based classification (reliable)
+  if (type === 1 || type === 3) return 'AMP';
+  if (type === 2 || type === 4) return 'CAB';
+
+  // Type 7: Delay or Reverb — distinguish by model name
+  if (type === 7) {
+    if (m.includes('delay') || m.includes('echo') || m.includes('dl4')) return 'DLY';
+    return 'RVB';
+  }
+
+  // Type 0: Everything else — classify by model name keywords
+  // Check dist/drive BEFORE comp (e.g. "CompulsiveDrive" contains "comp" but is a distortion)
+  if (m.includes('dist') || m.includes('drive') || m.includes('boost') || m.includes('fuzz') || m.includes('scream') || m.includes('rat')) return 'DST';
+  if (m.includes('compressor') || m.includes('squeeze') || m.includes('lacomp') || m.includes('redcomp') || /\bcomp\b/.test(m)) return 'PRE';
+  if (m.includes('eq') || m.includes('graphic') || m.includes('parametric')) return 'EQ';
+  if (m.includes('chorus') || m.includes('flanger') || m.includes('phaser') || m.includes('trem') || m.includes('vibe') || m.includes('vibrato') || m.includes('roto')) return 'MOD';
+  if (m.includes('wah') || m.includes('filter') || m.includes('mutant')) return 'WAH';
+  if (m.includes('pitch') || m.includes('octav') || m.includes('harmony') || m.includes('swell')) return 'PRE';
+  if (m.includes('gate') || m.includes('noise')) return 'NR';
+  if (m.includes('vol')) return 'VOL';
+
+  // Fallback: put unknowns in MOD
+  return 'MOD';
+}
+
+// ── Find closest GP-200 effect by module + keyword matching ────────────
+function findBestEffect(module: string, hlxModel: string): number {
+  const m = hlxModel.toLowerCase();
+  const candidates = Object.entries(EFFECT_MAP)
+    .filter(([, info]) => info.module === module)
+    .map(([id, info]) => ({ id: Number(id), name: info.name.toLowerCase() }));
+
+  if (candidates.length === 0) return MODULE_DEFAULTS[module] ?? 0;
+
+  // Try keyword matching
+  const keywords = m.replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(k => k.length > 2);
+  let bestScore = 0;
+  let bestId = candidates[0].id;
+
+  for (const c of candidates) {
+    let score = 0;
+    for (const kw of keywords) {
+      if (c.name.includes(kw)) score += kw.length;
+    }
+    // Bonus for specific well-known mappings
+    if (m.includes('plexi') && c.name.includes('uk')) score += 5;
+    if (m.includes('marshall') && c.name.includes('uk')) score += 5;
+    if (m.includes('fender') && (c.name.includes('dark') || c.name.includes('twin') || c.name.includes('tweedy'))) score += 5;
+    if (m.includes('mesa') && c.name.includes('mess')) score += 5;
+    if (m.includes('bogner') && c.name.includes('bog')) score += 5;
+    if (m.includes('vox') && c.name.includes('match')) score += 5;
+    if (m.includes('orange') && c.name.includes('knights')) score += 5;
+    if (m.includes('ubersonic') && c.name.includes('dizz')) score += 5;
+    if (m.includes('greenback') && c.name.includes('uk gr')) score += 5;
+    if (m.includes('caliv30') && c.name.includes('mess')) score += 5;
+    if (m.includes('analog') && c.name.includes('analog')) score += 5;
+    if (m.includes('tape') && c.name.includes('tape')) score += 5;
+    if (m.includes('plate') && c.name.includes('plate')) score += 5;
+    if (m.includes('room') && c.name.includes('room')) score += 5;
+    if (m.includes('hall') && c.name.includes('hall')) score += 5;
+    if (m.includes('spring') && c.name.includes('spring')) score += 5;
+    if (m.includes('shimmer') && c.name.includes('shimmer')) score += 5;
+    if (m.includes('chorus') && c.name.includes('chorus')) score += 5;
+    if (m.includes('flanger') && c.name.includes('jet')) score += 3;
+    if (m.includes('phaser') && c.name.includes('phase')) score += 5;
+    if (m.includes('tremolo') && c.name.includes('trem')) score += 5;
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestId = c.id;
+    }
+  }
+
+  return bestId;
+}
+
+// ── Normalize HLX parameter value to GP-200 range (0-100) ─────────────
+function normalizeParam(value: unknown, hlxMin = 0, hlxMax = 1): number {
+  if (typeof value !== 'number') return 50;
+  const clamped = Math.max(hlxMin, Math.min(hlxMax, value));
+  return Math.round(((clamped - hlxMin) / (hlxMax - hlxMin)) * 100);
+}
+
+// ── Extract params from HLX block → 15 float32 array ──────────────────
+function extractParams(block: HLXBlock, module: string): number[] {
+  const params = new Array(15).fill(0);
+
+  // Common param mapping based on module type
+  switch (module) {
+    case 'AMP': {
+      params[0] = normalizeParam(block['Drive'] ?? block['Gain'], 0, 1);    // Gain
+      params[1] = normalizeParam(block['Presence'], 0, 1);                  // Presence
+      params[2] = normalizeParam(block['ChVol'] ?? block['Master'], 0, 1);  // Volume
+      params[3] = normalizeParam(block['Bass'], 0, 1);                      // Bass
+      params[4] = normalizeParam(block['Mid'] ?? block['Middle'], 0, 1);    // Middle
+      params[5] = normalizeParam(block['Treble'], 0, 1);                    // Treble
+      break;
+    }
+    case 'DST': {
+      params[0] = normalizeParam(block['Gain'] ?? block['Drive'], 0, 1);
+      params[1] = normalizeParam(block['Tone'], 0, 1);
+      params[2] = normalizeParam(block['Level'] ?? block['Volume'], -60, 0);
+      break;
+    }
+    case 'DLY': {
+      params[0] = normalizeParam(block['Mix'], 0, 1);
+      // Time: HLX uses seconds (0-2+), GP-200 uses ms or enum
+      const time = typeof block['Time'] === 'number' ? block['Time'] : 0.5;
+      params[1] = Math.round(Math.min(time * 1000, 2000)); // ms, capped at 2000
+      params[2] = normalizeParam(block['Feedback'], 0, 1);
+      break;
+    }
+    case 'RVB': {
+      params[0] = normalizeParam(block['Mix'], 0, 1);
+      const predelay = typeof block['Predelay'] === 'number' ? block['Predelay'] : 0;
+      params[1] = Math.round(predelay * 1000); // ms
+      params[2] = normalizeParam(block['Decay'], 0, 10);
+      break;
+    }
+    case 'PRE': {
+      params[0] = normalizeParam(block['Threshold'] ?? block['Gain'] ?? block['Range'], 0, 1);
+      params[1] = normalizeParam(block['Ratio'] ?? block['Tone'] ?? block['Q'], 0, 1);
+      params[2] = normalizeParam(block['Level'] ?? block['Volume'], 0, 1);
+      break;
+    }
+    case 'MOD': {
+      params[0] = normalizeParam(block['Depth'], 0, 1);
+      params[1] = normalizeParam(block['Rate'] ?? block['Speed'], 0, 10);
+      params[2] = normalizeParam(block['Mix'] ?? block['Volume'] ?? block['Level'], 0, 1);
+      break;
+    }
+    case 'CAB': {
+      params[0] = normalizeParam(block['Level'] ?? block['Volume'], -60, 0);
+      const lowCut = typeof block['LowCut'] === 'number' ? block['LowCut'] : 80;
+      params[1] = Math.round(Math.min(lowCut, 500));
+      const highCut = typeof block['HighCut'] === 'number' ? block['HighCut'] : 12000;
+      params[2] = Math.round(Math.min(highCut, 20000));
+      break;
+    }
+    case 'NR': {
+      params[0] = normalizeParam(block['Threshold'], -96, 0);
+      break;
+    }
+    default: {
+      // Generic: try common parameter names
+      params[0] = normalizeParam(block['Gain'] ?? block['Drive'] ?? block['Level'], 0, 1);
+      params[1] = normalizeParam(block['Tone'] ?? block['Rate'], 0, 1);
+      params[2] = normalizeParam(block['Mix'] ?? block['Volume'], 0, 1);
+    }
+  }
+
+  return params;
+}
+
+// ── Main converter ─────────────────────────────────────────────────────
+export interface HLXPreset {
+  schema?: string;
+  data?: {
+    tone?: {
+      dsp0?: Record<string, HLXBlock>;
+      dsp1?: Record<string, HLXBlock>;
+      global?: Record<string, unknown>;
+      [key: string]: unknown;
+    };
+    meta?: {
+      name?: string;
+      author?: string;
+      band?: string;
+      song?: string;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export function convertHLX(hlx: HLXPreset): GP200Preset {
+  const meta = hlx.data?.meta ?? {};
+  const dsp0 = hlx.data?.tone?.dsp0 ?? {};
+
+  // Extract blocks sorted by position
+  const blocks: { key: string; block: HLXBlock }[] = [];
+  for (const [key, value] of Object.entries(dsp0)) {
+    if (key.startsWith('block') && value && typeof value === 'object' && '@model' in value) {
+      blocks.push({ key, block: value as HLXBlock });
+    }
+  }
+  blocks.sort((a, b) => (a.block['@position'] ?? 0) - (b.block['@position'] ?? 0));
+
+  // Classify each block → GP-200 module
+  const classified = blocks.map(({ block }) => ({
+    block,
+    module: classifyHLXBlock(block),
+  })).filter(({ module }) => module !== null) as { block: HLXBlock; module: string }[];
+
+  // Build 11 GP-200 effect slots — one per module, in fixed order
+  const effects: EffectSlot[] = GP200_MODULES.map((module, slotIndex) => {
+    // Find first HLX block that maps to this module
+    const match = classified.find(c => c.module === module);
+
+    if (match) {
+      const effectId = findBestEffect(module, match.block['@model']);
+      const enabled = match.block['@enabled'] !== false;
+      const params = extractParams(match.block, module);
+      return { slotIndex, effectId, enabled, params };
+    }
+
+    // No match — use default, disabled
+    return {
+      slotIndex,
+      effectId: MODULE_DEFAULTS[module] ?? 0,
+      enabled: false,
+      params: new Array(15).fill(0),
+    };
+  });
+
+  // Build preset name (max 16 chars for GP-200)
+  const rawName = meta.name ?? 'HLX Import';
+  const patchName = rawName.slice(0, 16);
+  const author = (meta.author ?? '').slice(0, 16) || undefined;
+
+  return {
+    version: '1',
+    patchName,
+    author,
+    effects,
+    checksum: 0,
+  };
+}

--- a/tests/unit/HLXConverter.test.ts
+++ b/tests/unit/HLXConverter.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { convertHLX } from '@/core/HLXConverter';
+import { PRSTEncoder } from '@/core/PRSTEncoder';
+import { PRSTDecoder } from '@/core/PRSTDecoder';
+import { GP200PresetSchema } from '@/core/types';
+import { getModuleName } from '@/core/effectNames';
+
+const HLX_DIR = join(process.cwd(), 'others/line6 helix stomp');
+
+const HLX_FILES = [
+  '+#StickPiuPiu.hlx',
+  '1.hlx',
+  '1984 New.hlx',
+  '2.hlx',
+  '_ GEKI _ HIZUMI.hlx',
+];
+
+function loadHLX(filename: string) {
+  const path = join(HLX_DIR, filename);
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+describe('HLXConverter', () => {
+  it('converts a minimal HLX to valid GP200Preset', () => {
+    const hlx = {
+      schema: 'L6Preset',
+      data: {
+        tone: { dsp0: {} },
+        meta: { name: 'Test', author: 'Me' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    expect(preset.patchName).toBe('Test');
+    expect(preset.author).toBe('Me');
+    expect(preset.effects).toHaveLength(11);
+    expect(() => GP200PresetSchema.parse(preset)).not.toThrow();
+  });
+
+  it('handles missing meta gracefully', () => {
+    const hlx = { data: { tone: { dsp0: {} } } };
+    const preset = convertHLX(hlx);
+    expect(preset.patchName).toBe('HLX Import');
+    expect(preset.author).toBeUndefined();
+  });
+
+  it('truncates long names to 16 chars', () => {
+    const hlx = {
+      data: {
+        tone: { dsp0: {} },
+        meta: { name: 'This Is A Very Long Preset Name That Exceeds Limit' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    expect(preset.patchName.length).toBeLessThanOrEqual(16);
+  });
+
+  it('maps AMP blocks to AMP module', () => {
+    const hlx = {
+      data: {
+        tone: {
+          dsp0: {
+            block0: {
+              '@model': 'HD2_AmpBritPlexiBrt',
+              '@type': 1,
+              '@position': 0,
+              '@enabled': true,
+              Drive: 0.8,
+              Bass: 0.5,
+              Mid: 0.6,
+              Treble: 0.7,
+              Presence: 0.5,
+              ChVol: 0.6,
+            },
+          },
+        },
+        meta: { name: 'AmpTest' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    // AMP is slot 3 (index in GP200_MODULES)
+    const ampSlot = preset.effects[3];
+    expect(ampSlot.enabled).toBe(true);
+    expect(getModuleName(ampSlot.effectId)).toBe('AMP');
+    expect(ampSlot.params[0]).toBeGreaterThan(0); // Gain from Drive=0.8
+  });
+
+  it('maps Delay blocks to DLY module', () => {
+    const hlx = {
+      data: {
+        tone: {
+          dsp0: {
+            block0: {
+              '@model': 'HD2_DelayVintageDigitalV2',
+              '@type': 7,
+              '@position': 0,
+              '@enabled': true,
+              Mix: 0.35,
+              Time: 0.5,
+              Feedback: 0.45,
+            },
+          },
+        },
+        meta: { name: 'DlyTest' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    // DLY is slot 8
+    const dlySlot = preset.effects[8];
+    expect(dlySlot.enabled).toBe(true);
+    expect(getModuleName(dlySlot.effectId)).toBe('DLY');
+  });
+
+  it('maps Reverb blocks to RVB module', () => {
+    const hlx = {
+      data: {
+        tone: {
+          dsp0: {
+            block0: {
+              '@model': 'HD2_ReverbPlate',
+              '@type': 7,
+              '@position': 0,
+              '@enabled': true,
+              Mix: 0.2,
+              Decay: 3.0,
+            },
+          },
+        },
+        meta: { name: 'RvbTest' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    const rvbSlot = preset.effects[9];
+    expect(rvbSlot.enabled).toBe(true);
+    expect(getModuleName(rvbSlot.effectId)).toBe('RVB');
+  });
+
+  it('maps Distortion blocks to DST module', () => {
+    const hlx = {
+      data: {
+        tone: {
+          dsp0: {
+            block0: {
+              '@model': 'HD2_DistCompulsiveDrive',
+              '@type': 0,
+              '@position': 0,
+              '@enabled': true,
+            },
+          },
+        },
+        meta: { name: 'DstTest' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    const dstSlot = preset.effects[2];
+    expect(dstSlot.enabled).toBe(true);
+    expect(getModuleName(dstSlot.effectId)).toBe('DST');
+  });
+
+  it('disables unmatched modules', () => {
+    const hlx = {
+      data: {
+        tone: {
+          dsp0: {
+            block0: {
+              '@model': 'HD2_AmpBritPlexiBrt',
+              '@type': 1,
+              '@position': 0,
+              '@enabled': true,
+            },
+          },
+        },
+        meta: { name: 'Sparse' },
+      },
+    };
+    const preset = convertHLX(hlx);
+    // Only AMP should be enabled, rest disabled
+    const enabledCount = preset.effects.filter(e => e.enabled).length;
+    expect(enabledCount).toBe(1);
+    expect(preset.effects[3].enabled).toBe(true); // AMP
+  });
+});
+
+describe('HLXConverter with real .hlx files', () => {
+  for (const filename of HLX_FILES) {
+    const hlx = loadHLX(filename);
+
+    it.skipIf(!hlx)(`converts "${filename}" to valid GP200Preset`, () => {
+      const preset = convertHLX(hlx!);
+      expect(() => GP200PresetSchema.parse(preset)).not.toThrow();
+      expect(preset.effects).toHaveLength(11);
+      expect(preset.patchName.length).toBeGreaterThan(0);
+      expect(preset.patchName.length).toBeLessThanOrEqual(16);
+    });
+
+    it.skipIf(!hlx)(`"${filename}" roundtrips through PRST encode/decode`, () => {
+      const preset = convertHLX(hlx!);
+      const encoder = new PRSTEncoder();
+      const buf = new Uint8Array(encoder.encode(preset));
+      expect(buf.length).toBe(1224);
+      const decoded = new PRSTDecoder(buf).decode();
+      expect(decoded.patchName).toBe(preset.patchName);
+      expect(decoded.effects).toHaveLength(11);
+    });
+
+    it.skipIf(!hlx)(`"${filename}" has at least one enabled effect`, () => {
+      const preset = convertHLX(hlx!);
+      const enabledCount = preset.effects.filter(e => e.enabled).length;
+      expect(enabledCount).toBeGreaterThan(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- New `HLXConverter` parses Line6 HX Stomp `.hlx` (JSON) presets and converts to GP-200 format
- Best-effort effect mapping: AMP, DST, DLY, RVB, MOD, EQ, CAB, PRE, WAH, NR, VOL
- Keyword-based model matching (Plexi→UK 800, Mesa→Mess, Greenback→UK GRN, etc.)
- Parameter normalization from HLX ranges (0-1) to GP-200 ranges (0-100)
- FileUpload + editor accept `.hlx` files alongside `.prst`
- Purple "EXPERIMENTAL" badge shown when imported from HLX

## Test plan
- [x] 23 unit tests (synthetic + all 5 real .hlx sample files)
- [x] Roundtrip: HLX → GP200Preset → PRSTEncoder → PRSTDecoder → valid preset
- [ ] Visual playtest in Docker with real .hlx files

🤖 Generated with [Claude Code](https://claude.com/claude-code)