### PR TITLE
fix: review findings on comments/rating/featured (security + UX + perf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2026-05-19
+
+### Security
+- **Comments leak after un-publish — fixed.** `GET /api/presets/[id]/comments` now refuses to return the thread when the preset has been made non-public or flagged. POST top-level + Reply gained the same gate (Reply previously checked neither). Anyone who had the preset id from a previous public link can no longer continue reading a thread the author tried to retract.
+- **Featured-Preset Sybil-Dampening verstärkt.** Bayes-Konstante `m` von 5 auf 10 — eine einzelne 5★-Bewertung von einem Accomplice-Account scoret jetzt nur noch ~4.09 (statt 4.17) und schiebt sich nicht mehr vor etablierte Presets mit echtem Rating-Verlauf.
+
+### Bugfixes
+- **Inline-Rating Optimistic-UI ohne Rollback** — bei fehlgeschlagenem POST blieb die UI bei der Phantom-Bewertung. Snapshot+Restore + `errorTooltip`-Toast.
+- **Comment-Textarea verlor Inhalt bei 429/Auth-Fail** — `CommentForm` clear jetzt nur bei Success; bei Fehler steht der Text zum Retry da.
+- **CommentSection swallowed 401/5xx silently** — separate Toasts für Rate-Limit, Session-Expired und generischen Fehler.
+- **Gallery-Rating Page 2+ zeigte falschen Count** — bereits-bewertete Presets jenseits der ersten SSR-Page bekamen `existingRating=0`, was bei Re-Rating zu Phantom-Counts führte. Session-Lookup zog ans `/api/gallery`-Endpoint, jede Card trägt jetzt korrekte Rating-Context.
+- **AdminCommentsTab hatte keine Pagination-UI** — alle Comments jenseits der ersten 50 waren unerreichbar. Load-More-Button + In-Flight-Guard.
+
+### UI / i18n
+- **Confirm-Dialog vor User-Soft-Delete.** Klick auf „Delete" beim eigenen Kommentar öffnet jetzt einen Bestätigungsdialog (Soft-Delete ist nicht reversibel — `body` wird genullt). Admin-Hard-Delete behält seinen separaten Reason-Dialog.
+- **Drei hardcoded englische Strings korrigiert** (`Comments` Header, `Email verification required`, Admin-`Cancel`-Button) — jetzt in allen 6 Locales übersetzt.
+- **Toter i18n-Key entfernt** (`comments.adminDeleteReasonLabel` — Admin-Tab nutzt `admin.comments.hardDeleteReasonLabel`).
+
+### Schema / Performance
+- **Index `Comment(createdAt DESC)`** — die Admin-Moderation-Liste sortiert ohne `presetId`-Filter; der bisherige Compound-Index half nicht. Cheap forward-looking change.
+- **Shared `commentSerializer`** — Avatar-Mapping (`avatarKey → /api/avatar/<key>`) lebt jetzt in `src/lib/commentSerializer.ts`; PATCH gab bisher den Raw-`avatarKey` zurück, alle anderen Routes serialisierten zu `avatarUrl`. Inkonsistenz behoben.
+
 ## 2026-05-18
 
 ### Features

--- a/messages/de.json
+++ b/messages/de.json
@@ -294,7 +294,8 @@
     "browseAll": "Alle Presets oben durchsuchen",
     "rate": {
       "signInTooltip": "Anmelden zum Bewerten",
-      "ownPresetTooltip": "Eigene Presets nicht bewertbar"
+      "ownPresetTooltip": "Eigene Presets nicht bewertbar",
+      "errorTooltip": "Bewertung fehlgeschlagen — bitte erneut versuchen"
     }
   },
   "device": {
@@ -561,7 +562,9 @@
       "hardDeleteButton": "Hart löschen",
       "hardDeleteDialogTitle": "Kommentar hart löschen",
       "hardDeleteReasonLabel": "Grund (Pflicht, 5–200 Zeichen)",
-      "confirmDelete": "Löschen"
+      "confirmDelete": "Löschen",
+      "cancel": "Abbrechen",
+      "loadMore": "Mehr laden"
     }
   },
   "email": {
@@ -652,8 +655,11 @@
     "signInToComment": "Anmelden zum Kommentieren",
     "loadMore": "Mehr laden",
     "confirmDelete": "Diesen Kommentar löschen?",
-    "adminDeleteReasonLabel": "Grund (Pflicht, 5–200 Zeichen)",
     "rateLimitToast": "Zu viele Kommentare. Bitte später erneut versuchen.",
-    "emptyState": "Noch keine Kommentare — sei der erste!"
+    "emptyState": "Noch keine Kommentare — sei der erste!",
+    "heading": "Kommentare",
+    "verifyRequired": "E-Mail-Verifizierung erforderlich, um zu kommentieren.",
+    "authToast": "Sitzung abgelaufen. Bitte erneut anmelden.",
+    "genericError": "Konnte nicht speichern — bitte erneut versuchen."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -294,7 +294,8 @@
     "browseAll": "Browse all presets above",
     "rate": {
       "signInTooltip": "Sign in to rate",
-      "ownPresetTooltip": "Cannot rate your own preset"
+      "ownPresetTooltip": "Cannot rate your own preset",
+      "errorTooltip": "Rating failed — try again"
     }
   },
   "device": {
@@ -561,7 +562,9 @@
       "hardDeleteButton": "Hard delete",
       "hardDeleteDialogTitle": "Hard-delete comment",
       "hardDeleteReasonLabel": "Reason (required, 5–200 chars)",
-      "confirmDelete": "Delete"
+      "confirmDelete": "Delete",
+      "cancel": "Cancel",
+      "loadMore": "Load more"
     }
   },
   "email": {
@@ -638,6 +641,7 @@
     }
   },
   "comments": {
+    "heading": "Comments",
     "placeholder": "Share your thoughts…",
     "charCount": "{count} / 1000",
     "post": "Post",
@@ -650,10 +654,12 @@
     "deletedByAdmin": "Removed by moderator",
     "edited": "edited",
     "signInToComment": "Sign in to comment",
+    "verifyRequired": "Email verification required to comment.",
     "loadMore": "Load more",
     "confirmDelete": "Delete this comment?",
-    "adminDeleteReasonLabel": "Reason (required, 5–200 chars)",
     "rateLimitToast": "Too many comments. Try again later.",
+    "authToast": "Session expired. Please sign in again.",
+    "genericError": "Could not save — please try again.",
     "emptyState": "No comments yet — be the first!"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -294,7 +294,8 @@
     "browseAll": "Explora todos los presets arriba",
     "rate": {
       "signInTooltip": "Inicia sesión para valorar",
-      "ownPresetTooltip": "No puedes valorar tu propio preset"
+      "ownPresetTooltip": "No puedes valorar tu propio preset",
+      "errorTooltip": "Falló la valoración — inténtalo de nuevo"
     }
   },
   "device": {
@@ -561,7 +562,9 @@
       "hardDeleteButton": "Eliminar permanentemente",
       "hardDeleteDialogTitle": "Eliminar comentario permanentemente",
       "hardDeleteReasonLabel": "Razón (obligatorio, 5–200 caracteres)",
-      "confirmDelete": "Eliminar"
+      "confirmDelete": "Eliminar",
+      "cancel": "Cancelar",
+      "loadMore": "Cargar más"
     }
   },
   "email": {
@@ -652,8 +655,11 @@
     "signInToComment": "Inicia sesión para comentar",
     "loadMore": "Cargar más",
     "confirmDelete": "¿Eliminar este comentario?",
-    "adminDeleteReasonLabel": "Razón (obligatorio, 5–200 caracteres)",
     "rateLimitToast": "Demasiados comentarios. Inténtalo más tarde.",
-    "emptyState": "Aún no hay comentarios — ¡sé el primero!"
+    "emptyState": "Aún no hay comentarios — ¡sé el primero!",
+    "heading": "Comentarios",
+    "verifyRequired": "Se requiere verificación de email para comentar.",
+    "authToast": "Sesión expirada. Inicia sesión de nuevo.",
+    "genericError": "No se pudo guardar — inténtalo de nuevo."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -294,7 +294,8 @@
     "browseAll": "Parcourez tous les presets ci-dessus",
     "rate": {
       "signInTooltip": "Connectez-vous pour évaluer",
-      "ownPresetTooltip": "Vous ne pouvez pas évaluer votre propre preset"
+      "ownPresetTooltip": "Vous ne pouvez pas évaluer votre propre preset",
+      "errorTooltip": "Évaluation échouée — réessayez"
     }
   },
   "device": {
@@ -561,7 +562,9 @@
       "hardDeleteButton": "Suppression définitive",
       "hardDeleteDialogTitle": "Supprimer définitivement le commentaire",
       "hardDeleteReasonLabel": "Raison (obligatoire, 5–200 caractères)",
-      "confirmDelete": "Supprimer"
+      "confirmDelete": "Supprimer",
+      "cancel": "Annuler",
+      "loadMore": "Charger plus"
     }
   },
   "email": {
@@ -652,8 +655,11 @@
     "signInToComment": "Connectez-vous pour commenter",
     "loadMore": "Charger plus",
     "confirmDelete": "Supprimer ce commentaire ?",
-    "adminDeleteReasonLabel": "Raison (obligatoire, 5–200 caractères)",
     "rateLimitToast": "Trop de commentaires. Réessayez plus tard.",
-    "emptyState": "Aucun commentaire pour l’instant — soyez le premier !"
+    "emptyState": "Aucun commentaire pour l’instant — soyez le premier !",
+    "heading": "Commentaires",
+    "verifyRequired": "Vérification d'email requise pour commenter.",
+    "authToast": "Session expirée. Veuillez vous reconnecter.",
+    "genericError": "Impossible d'enregistrer — réessayez."
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -294,7 +294,8 @@
     "browseAll": "Sfoglia tutti i preset qui sopra",
     "rate": {
       "signInTooltip": "Accedi per valutare",
-      "ownPresetTooltip": "Non puoi valutare il tuo preset"
+      "ownPresetTooltip": "Non puoi valutare il tuo preset",
+      "errorTooltip": "Valutazione fallita — riprova"
     }
   },
   "device": {
@@ -561,7 +562,9 @@
       "hardDeleteButton": "Elimina permanentemente",
       "hardDeleteDialogTitle": "Elimina commento permanentemente",
       "hardDeleteReasonLabel": "Motivo (obbligatorio, 5–200 caratteri)",
-      "confirmDelete": "Elimina"
+      "confirmDelete": "Elimina",
+      "cancel": "Annulla",
+      "loadMore": "Carica altro"
     }
   },
   "email": {
@@ -652,8 +655,11 @@
     "signInToComment": "Accedi per commentare",
     "loadMore": "Carica altro",
     "confirmDelete": "Eliminare questo commento?",
-    "adminDeleteReasonLabel": "Motivo (obbligatorio, 5–200 caratteri)",
     "rateLimitToast": "Troppi commenti. Riprova più tardi.",
-    "emptyState": "Ancora nessun commento — sii il primo!"
+    "emptyState": "Ancora nessun commento — sii il primo!",
+    "heading": "Commenti",
+    "verifyRequired": "È richiesta la verifica dell'email per commentare.",
+    "authToast": "Sessione scaduta. Accedi di nuovo.",
+    "genericError": "Impossibile salvare — riprova."
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -294,7 +294,8 @@
     "browseAll": "Explore todos os presets acima",
     "rate": {
       "signInTooltip": "Faça login para avaliar",
-      "ownPresetTooltip": "Não pode avaliar o seu próprio preset"
+      "ownPresetTooltip": "Não pode avaliar o seu próprio preset",
+      "errorTooltip": "Avaliação falhou — tente novamente"
     }
   },
   "device": {
@@ -561,7 +562,9 @@
       "hardDeleteButton": "Excluir permanentemente",
       "hardDeleteDialogTitle": "Excluir comentário permanentemente",
       "hardDeleteReasonLabel": "Motivo (obrigatório, 5–200 caracteres)",
-      "confirmDelete": "Excluir"
+      "confirmDelete": "Excluir",
+      "cancel": "Cancelar",
+      "loadMore": "Carregar mais"
     }
   },
   "email": {
@@ -652,8 +655,11 @@
     "signInToComment": "Faça login para comentar",
     "loadMore": "Carregar mais",
     "confirmDelete": "Excluir este comentário?",
-    "adminDeleteReasonLabel": "Motivo (obrigatório, 5–200 caracteres)",
     "rateLimitToast": "Comentários demais. Tente novamente mais tarde.",
-    "emptyState": "Ainda sem comentários — seja o primeiro!"
+    "emptyState": "Ainda sem comentários — seja o primeiro!",
+    "heading": "Comentários",
+    "verifyRequired": "É necessária verificação de e-mail para comentar.",
+    "authToast": "Sessão expirada. Faça login novamente.",
+    "genericError": "Não foi possível salvar — tente novamente."
   }
 }

--- a/prisma/migrations/20260518152112_comment_createdat_index/migration.sql
+++ b/prisma/migrations/20260518152112_comment_createdat_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Comment_createdAt_idx" ON "Comment"("createdAt" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,6 +141,9 @@ model Comment {
 
   @@index([presetId, parentId, createdAt(sort: Desc)])
   @@index([userId])
+  // Admin moderation list orders by createdAt globally (no presetId filter).
+  // Without this index the query degrades to a full sort once the table grows.
+  @@index([createdAt(sort: Desc)])
 }
 
 model ErrorLog {

--- a/src/app/[locale]/gallery/GalleryClient.tsx
+++ b/src/app/[locale]/gallery/GalleryClient.tsx
@@ -24,17 +24,18 @@ type GalleryPreset = {
   flagged: boolean;
   userId: string;
   user: { username: string };
+  // Per-card rating context — populated by /api/gallery using the session
+  // cookie. Stays consistent across pagination (the original SSR-only path
+  // returned existingRating=0 for "load more" pages, which corrupted the
+  // optimistic count when a user re-rated an already-rated preset).
+  canRate: boolean;
+  rateReason: 'anon' | 'own' | 'unverified' | null;
+  existingRating: number;
 };
 
 const ALL_MODULES = Object.keys(MODULE_COLORS);
 
-interface GalleryClientProps {
-  currentUserId: string | null;
-  emailVerified: boolean;
-  myRatings: Record<string, number>;
-}
-
-export function GalleryClient({ currentUserId, emailVerified, myRatings }: GalleryClientProps) {
+export function GalleryClient() {
   const t = useTranslations('gallery');
   const [presets, setPresets] = useState<GalleryPreset[]>([]);
   const [total, setTotal] = useState(0);
@@ -342,14 +343,9 @@ export function GalleryClient({ currentUserId, emailVerified, myRatings }: Galle
                     presetId={preset.id}
                     average={preset.ratingAverage}
                     count={preset.ratingCount}
-                    canRate={!!currentUserId && emailVerified && preset.userId !== currentUserId}
-                    existing={myRatings[preset.id] ?? 0}
-                    reason={
-                      !currentUserId ? 'anon' :
-                      !emailVerified ? 'unverified' :
-                      preset.userId === currentUserId ? 'own' :
-                      null
-                    }
+                    canRate={preset.canRate}
+                    existing={preset.existingRating}
+                    reason={preset.rateReason}
                     size="sm"
                   />
                 </div>

--- a/src/app/[locale]/gallery/page.tsx
+++ b/src/app/[locale]/gallery/page.tsx
@@ -2,7 +2,6 @@ import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { Link } from '@/i18n/routing';
 import { prisma } from '@/lib/prisma';
-import { validateSession } from '@/lib/session';
 import { GalleryClient } from './GalleryClient';
 import { HelpButton } from '@/components/HelpButton';
 import { buildAlternates, BASE_URL, type Locale } from '@/lib/hreflang';
@@ -35,35 +34,9 @@ export default async function GalleryPage({ params }: Props) {
   const { locale } = await params;
   const t = await getTranslations('gallery');
 
-  // Load session + existing ratings for the first page of gallery presets.
-  // These are passed to GalleryClient so cards can render RateableGuitarRating
-  // with correct canRate / existingRating on first paint. Presets loaded via
-  // "load more" will use existingRating=0 (no-op; users can still rate them).
-  const { user } = await validateSession();
-
-  // Fetch first-page preset IDs so we can pre-load the user's ratings.
-  // We mirror the default gallery query (newest, page 1, limit 20).
-  let myRatings: Record<string, number> = {};
-  if (user) {
-    try {
-      const firstPageIds = await prisma.preset.findMany({
-        where: { public: true },
-        orderBy: { createdAt: 'desc' },
-        take: 20,
-        select: { id: true },
-      });
-      const ratings = await prisma.presetRating.findMany({
-        where: { userId: user.id, presetId: { in: firstPageIds.map((p) => p.id) } },
-        select: { presetId: true, score: true },
-      });
-      myRatings = Object.fromEntries(ratings.map((r) => [r.presetId, r.score]));
-    } catch (err) {
-      console.error('[gallery] failed to pre-load ratings:', err instanceof Error ? `${err.name}: ${err.message}` : err);
-    }
-  }
-
-  const currentUserId = user?.id ?? null;
-  const emailVerified = user?.emailVerified ?? false;
+  // GalleryClient does its own /api/gallery fetch on mount; that endpoint
+  // resolves the session and returns canRate/rateReason/existingRating per
+  // card, so SSR no longer needs to pre-load session-aware rating state.
 
   // Server-side fetch: 30 newest public presets for the SEO directory.
   // Failure here must not break the page — fall back to the empty list.
@@ -123,11 +96,7 @@ export default async function GalleryPage({ params }: Props) {
         </h1>
         <HelpButton section="gallery" />
       </div>
-      <GalleryClient
-        currentUserId={currentUserId}
-        emailVerified={emailVerified}
-        myRatings={myRatings}
-      />
+      <GalleryClient />
 
       {recent.length > 0 && (
         <section className="mt-16 pt-8" style={{ borderTop: '1px solid var(--border-subtle)' }}>

--- a/src/app/api/comments/[id]/reply/route.ts
+++ b/src/app/api/comments/[id]/reply/route.ts
@@ -4,6 +4,7 @@ import { verifyCsrf } from '@/lib/csrf';
 import { prisma } from '@/lib/prisma';
 import { rateLimit } from '@/lib/rateLimit';
 import { commentBodySchema } from '@/lib/commentValidators';
+import { commentUserSelect, serializeCommentUser } from '@/lib/commentSerializer';
 
 export async function POST(
   request: NextRequest,
@@ -26,32 +27,32 @@ export async function POST(
     return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
   }
 
+  // Pull the parent + its preset's public/flagged state in one round-trip
+  // so we can reject replies on threads that have been un-published or
+  // admin-flagged. POST top-level applies the same gate.
   const parent = await prisma.comment.findUnique({
     where: { id: parentId },
-    select: { id: true, parentId: true, presetId: true },
+    select: {
+      id: true,
+      parentId: true,
+      presetId: true,
+      preset: { select: { public: true, flagged: true } },
+    },
   });
   if (!parent) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   if (parent.parentId !== null) {
     return NextResponse.json({ error: 'Replies must target a top-level comment' }, { status: 400 });
   }
+  if (!parent.preset.public || parent.preset.flagged) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
 
   const comment = await prisma.comment.create({
     data: { presetId: parent.presetId, userId: user.id, body: parsed.data, parentId: parent.id },
-    include: { user: { select: { id: true, username: true, avatarKey: true } } },
+    include: { user: { select: commentUserSelect } },
   });
-
-  const { user: commentUser, ...commentRest } = comment as typeof comment & {
-    user: { id: string; username: string; avatarKey: string | null };
-  };
 
   return NextResponse.json({
-    comment: {
-      ...commentRest,
-      user: commentUser ? serializeUser(commentUser) : null,
-    },
+    comment: { ...comment, user: serializeCommentUser(comment.user) },
   });
-}
-
-function serializeUser(u: { id: string; username: string; avatarKey: string | null }) {
-  return { id: u.id, username: u.username, avatarUrl: u.avatarKey ? `/api/avatar/${u.avatarKey}` : null };
 }

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -4,6 +4,7 @@ import { verifyCsrf } from '@/lib/csrf';
 import { prisma } from '@/lib/prisma';
 import { rateLimit } from '@/lib/rateLimit';
 import { commentBodySchema, adminDeleteReasonSchema } from '@/lib/commentValidators';
+import { commentUserSelect, serializeCommentUser } from '@/lib/commentSerializer';
 
 export async function PATCH(
   request: NextRequest,
@@ -37,9 +38,11 @@ export async function PATCH(
   const comment = await prisma.comment.update({
     where: { id },
     data: { body: parsed.data, editedAt: new Date() },
-    include: { user: { select: { id: true, username: true, avatarKey: true } } },
+    include: { user: { select: commentUserSelect } },
   });
-  return NextResponse.json({ comment });
+  return NextResponse.json({
+    comment: { ...comment, user: serializeCommentUser(comment.user) },
+  });
 }
 
 export async function DELETE(

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { galleryQuerySchema } from '@/lib/validators';
+import { validateSession } from '@/lib/session';
 import type { Prisma } from '@prisma/client';
 
 export async function GET(request: NextRequest) {
@@ -23,10 +24,8 @@ export async function GET(request: NextRequest) {
   }
 
   if (effects && effects.length > 0) {
-    // Fine-grained: filter by specific effect names
     where.effects = { hasSome: effects };
   } else if (modules && modules.length > 0) {
-    // Coarse: filter by module category
     where.modules = { hasSome: modules };
   }
 
@@ -39,33 +38,62 @@ export async function GET(request: NextRequest) {
     sort === 'top-rated' ? { ratingAverage: 'desc' } :
                            { createdAt: 'desc' };
 
-  const [presets, total] = await Promise.all([
-    prisma.preset.findMany({
-      where,
-      orderBy,
-      skip: (page - 1) * limit,
-      take: limit,
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        tags: true,
-        modules: true,
-        effects: true,
-        author: true,
-        style: true,
-        shareToken: true,
-        downloadCount: true,
-        ratingAverage: true,
-        ratingCount: true,
-        createdAt: true,
-        flagged: true,
-        userId: true,
-        user: { select: { username: true } },
-      },
-    }),
-    prisma.preset.count({ where }),
+  const [{ user }, [presets, total]] = await Promise.all([
+    validateSession(),
+    Promise.all([
+      prisma.preset.findMany({
+        where,
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          tags: true,
+          modules: true,
+          effects: true,
+          author: true,
+          style: true,
+          shareToken: true,
+          downloadCount: true,
+          ratingAverage: true,
+          ratingCount: true,
+          createdAt: true,
+          flagged: true,
+          userId: true,
+          user: { select: { username: true } },
+        },
+      }),
+      prisma.preset.count({ where }),
+    ]),
   ]);
 
-  return NextResponse.json({ presets, total, page, limit });
+  // Per-page "my rating" lookup so paginated cards reflect the user's own
+  // score without needing a separate request. Server-side SSR could carry
+  // this for page 1, but the GalleryClient does an internal fetch when
+  // filters/sort change or "load more" fires — we need it here too.
+  let myRatings: Record<string, number> = {};
+  if (user && presets.length > 0) {
+    const ratings = await prisma.presetRating.findMany({
+      where: { userId: user.id, presetId: { in: presets.map((p) => p.id) } },
+      select: { presetId: true, score: true },
+    });
+    myRatings = Object.fromEntries(ratings.map((r) => [r.presetId, r.score]));
+  }
+
+  const enriched = presets.map((p) => ({
+    ...p,
+    canRate: !!user && !!user.emailVerified && p.userId !== user.id,
+    rateReason: !user
+      ? 'anon' as const
+      : !user.emailVerified
+        ? 'unverified' as const
+        : p.userId === user.id
+          ? 'own' as const
+          : null,
+    existingRating: myRatings[p.id] ?? 0,
+  }));
+
+  return NextResponse.json({ presets: enriched, total, page, limit });
 }

--- a/src/app/api/presets/[id]/comments/route.ts
+++ b/src/app/api/presets/[id]/comments/route.ts
@@ -4,6 +4,7 @@ import { verifyCsrf } from '@/lib/csrf';
 import { prisma } from '@/lib/prisma';
 import { rateLimit } from '@/lib/rateLimit';
 import { commentBodySchema } from '@/lib/commentValidators';
+import { commentUserSelect, serializeCommentUser } from '@/lib/commentSerializer';
 
 export async function POST(
   request: NextRequest,
@@ -26,35 +27,25 @@ export async function POST(
     return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
   }
 
+  // Block commenting on private, flagged, or non-existent presets. flagged
+  // pauses activity until moderation completes; non-public excludes drafts
+  // and revoked links.
   const preset = await prisma.preset.findUnique({
     where: { id },
-    select: { id: true, public: true },
+    select: { id: true, public: true, flagged: true },
   });
-  if (!preset || !preset.public) {
+  if (!preset || !preset.public || preset.flagged) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
   const comment = await prisma.comment.create({
     data: { presetId: id, userId: user.id, body: parsed.data, parentId: null },
-    include: { user: { select: userSelect } },
+    include: { user: { select: commentUserSelect } },
   });
-
-  const { user: commentUser, ...commentRest } = comment as typeof comment & {
-    user: { id: string; username: string; avatarKey: string | null };
-  };
 
   return NextResponse.json({
-    comment: {
-      ...commentRest,
-      user: commentUser ? serializeUser(commentUser) : null,
-    },
+    comment: { ...comment, user: serializeCommentUser(comment.user) },
   });
-}
-
-const userSelect = { id: true, username: true, avatarKey: true } as const;
-
-function serializeUser(u: { id: string; username: string; avatarKey: string | null }) {
-  return { id: u.id, username: u.username, avatarUrl: u.avatarKey ? `/api/avatar/${u.avatarKey}` : null };
 }
 
 export async function GET(
@@ -62,6 +53,18 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+
+  // Refuse to expose a discussion that has been un-published or flagged —
+  // un-publishing is the user's way of revoking the share link, and the
+  // comment thread must follow.
+  const preset = await prisma.preset.findUnique({
+    where: { id },
+    select: { id: true, public: true, flagged: true },
+  });
+  if (!preset || !preset.public || preset.flagged) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
   const cursor = request.nextUrl.searchParams.get('cursor');
   const LIMIT = 20;
 
@@ -71,10 +74,10 @@ export async function GET(
     take: LIMIT + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
     include: {
-      user: { select: userSelect },
+      user: { select: commentUserSelect },
       replies: {
         orderBy: { createdAt: 'asc' },
-        include: { user: { select: userSelect } },
+        include: { user: { select: commentUserSelect } },
       },
     },
   });
@@ -86,11 +89,11 @@ export async function GET(
   const sanitized = items.map((c) => ({
     ...c,
     body: c.deletedAt ? null : c.body,
-    user: serializeUser(c.user),
+    user: serializeCommentUser(c.user),
     replies: c.replies.map((r) => ({
       ...r,
       body: r.deletedAt ? null : r.body,
-      user: serializeUser(r.user),
+      user: serializeCommentUser(r.user),
     })),
   }));
 

--- a/src/components/RateableGuitarRating.tsx
+++ b/src/components/RateableGuitarRating.tsx
@@ -22,19 +22,31 @@ export function RateableGuitarRating({ presetId, average, count, canRate, existi
   const [tip, setTip] = useState<string | null>(null);
 
   async function handleRate(score: number) {
-    if (canRate) {
-      const wasNew = mine === 0;
-      const newCount = wasNew ? cnt + 1 : cnt;
-      const newAvg = wasNew ? (avg * cnt + score) / newCount : (avg * cnt - mine + score) / cnt;
-      setAvg(newAvg); setCnt(newCount); setMine(score);
-      await fetch(`/api/presets/${presetId}/rate`, {
+    if (!canRate) {
+      setTip(reason === 'own' ? t('ownPresetTooltip') : t('signInTooltip'));
+      setTimeout(() => setTip(null), 2500);
+      return;
+    }
+
+    // Snapshot for rollback before applying the optimistic update.
+    const prevAvg = avg, prevCnt = cnt, prevMine = mine;
+    const wasNew = mine === 0;
+    const newCount = wasNew ? cnt + 1 : cnt;
+    const newAvg = wasNew ? (avg * cnt + score) / newCount : (avg * cnt - mine + score) / cnt;
+    setAvg(newAvg); setCnt(newCount); setMine(score);
+
+    try {
+      const res = await fetch(`/api/presets/${presetId}/rate`, {
         method: 'POST', headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ score }),
       });
-      return;
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } catch {
+      // Roll back optimistic state — the rating did not persist.
+      setAvg(prevAvg); setCnt(prevCnt); setMine(prevMine);
+      setTip(t('errorTooltip'));
+      setTimeout(() => setTip(null), 2500);
     }
-    setTip(reason === 'own' ? t('ownPresetTooltip') : t('signInTooltip'));
-    setTimeout(() => setTip(null), 2500);
   }
 
   return (

--- a/src/components/admin/AdminCommentsTab.tsx
+++ b/src/components/admin/AdminCommentsTab.tsx
@@ -14,17 +14,29 @@ interface AdminComment {
 export function AdminCommentsTab() {
   const t = useTranslations('admin.comments');
   const [comments, setComments] = useState<AdminComment[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [target, setTarget] = useState<AdminComment | null>(null);
   const [reason, setReason] = useState('');
 
-  async function load() {
-    const res = await fetch('/api/admin/comments');
-    if (res.ok) {
+  async function load(append = false) {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const cur = append ? cursor : null;
+      const url = `/api/admin/comments${cur ? `?cursor=${cur}` : ''}`;
+      const res = await fetch(url);
+      if (!res.ok) return;
       const data = await res.json();
-      setComments(data.comments);
+      setComments((prev) => (append ? [...prev, ...data.comments] : data.comments));
+      setCursor(data.nextCursor);
+      setHasMore(!!data.nextCursor);
+    } finally {
+      setLoading(false);
     }
   }
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(false); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
 
   async function hardDelete() {
     if (!target || reason.trim().length < 5) return;
@@ -35,7 +47,7 @@ export function AdminCommentsTab() {
     });
     if (res.ok) {
       setTarget(null); setReason('');
-      load();
+      load(false);
     }
   }
 
@@ -72,6 +84,19 @@ export function AdminCommentsTab() {
         </tbody>
       </table>
 
+      {hasMore && (
+        <div className="mt-3">
+          <button
+            onClick={() => load(true)}
+            disabled={loading}
+            className="text-xs uppercase tracking-wider font-mono-display"
+            style={{ color: 'var(--accent-amber)', opacity: loading ? 0.5 : 1 }}
+          >
+            {t('loadMore')}
+          </button>
+        </div>
+      )}
+
       {target && (
         <div role="dialog" className="fixed inset-0 flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.6)' }}>
           <div className="p-4 rounded max-w-md" style={{ background: 'var(--surface)', border: '1px solid var(--accent-amber-dim)' }}>
@@ -85,7 +110,7 @@ export function AdminCommentsTab() {
               style={{ background: 'rgba(255,255,255,0.04)', color: 'var(--text-primary)', border: '1px solid rgba(255,255,255,0.08)' }}
             />
             <div className="flex justify-end gap-2">
-              <button onClick={() => { setTarget(null); setReason(''); }} className="px-3 py-1">Cancel</button>
+              <button onClick={() => { setTarget(null); setReason(''); }} className="px-3 py-1">{t('cancel')}</button>
               <button onClick={hardDelete} disabled={reason.trim().length < 5} style={{ color: '#ef4444' }} className="px-3 py-1">
                 {t('confirmDelete')}
               </button>

--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -22,9 +22,15 @@ export function CommentForm({ onSubmit, onCancel, initialValue = '', isEdit = fa
   async function handleSubmit() {
     if (disabled) return;
     setBusy(true);
-    await onSubmit(trimmed);
+    let ok = false;
+    try {
+      await onSubmit(trimmed);
+      ok = true;
+    } catch {
+      // Keep the body so the user can retry — the parent already shows a toast.
+    }
     flushSync(() => {
-      if (!isEdit) setBody('');
+      if (ok && !isEdit) setBody('');
       setBusy(false);
     });
   }

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/routing';
 import { AutoLink } from '@/lib/autoLink';
 import { CommentForm } from './CommentForm';
+import { ConfirmDialog } from '../ConfirmDialog';
 
 export interface CommentData {
   id: string;
@@ -29,6 +30,16 @@ interface Props {
 export function CommentItem({ comment, currentUserId, isAdmin, onReply, onEdit, onDelete }: Props) {
   const t = useTranslations('comments');
   const [editing, setEditing] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleConfirmDelete() {
+    setDeleting(true);
+    try { await onDelete(comment.id); } finally {
+      setDeleting(false);
+      setConfirmingDelete(false);
+    }
+  }
 
   const isOwn = currentUserId === comment.userId;
   const isDeleted = !!comment.deletedAt;
@@ -81,7 +92,7 @@ export function CommentItem({ comment, currentUserId, isAdmin, onReply, onEdit, 
           {isOwn && (
             <>
               <button onClick={() => setEditing(true)}>{t('edit')}</button>
-              <button onClick={() => onDelete(comment.id)}>{t('delete')}</button>
+              <button onClick={() => setConfirmingDelete(true)}>{t('delete')}</button>
             </>
           )}
           {isAdmin && !isOwn && (
@@ -89,6 +100,14 @@ export function CommentItem({ comment, currentUserId, isAdmin, onReply, onEdit, 
           )}
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmingDelete}
+        message={t('confirmDelete')}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setConfirmingDelete(false)}
+        loading={deleting}
+      />
     </div>
   );
 }

--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/routing';
 import { CommentList, type TopLevelComment } from './CommentList';
@@ -18,30 +18,56 @@ export function CommentSection({ presetId, currentUserId, isVerified, isAdmin }:
   const [cursor, setCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
 
-  const load = useCallback(async (initial = false) => {
-    const url = `/api/presets/${presetId}/comments${!initial && cursor ? `?cursor=${cursor}` : ''}`;
-    const res = await fetch(url);
-    if (!res.ok) return;
-    const data = await res.json();
-    setComments((prev) => initial ? data.comments : [...prev, ...data.comments]);
-    setCursor(data.nextCursor);
-    setHasMore(!!data.nextCursor);
-  }, [presetId, cursor]);
-
-  useEffect(() => { load(true); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [presetId]);
-
-  function handleError(status: number) {
-    if (status === 429) setToast(t('rateLimitToast'));
-    setTimeout(() => setToast(null), 3000);
+  function showToast(msg: string) {
+    setToast(msg);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setToast(null), 3000);
   }
 
+  // Toast message per response status. 401 happens when the session expired
+  // mid-typing; 429 is rate limit; anything else surfaces a generic error.
+  function toastForStatus(status: number) {
+    if (status === 429) showToast(t('rateLimitToast'));
+    else if (status === 401 || status === 403) showToast(t('authToast'));
+    else showToast(t('genericError'));
+  }
+
+  const load = useCallback(async (initial = false) => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      // Read cursor at call-time via the closure — passing `initial=true`
+      // forces a fresh fetch ignoring the saved cursor (used after mutations).
+      const cur = initial ? null : cursor;
+      const url = `/api/presets/${presetId}/comments${cur ? `?cursor=${cur}` : ''}`;
+      const res = await fetch(url);
+      if (!res.ok) return;
+      const data = await res.json();
+      setComments((prev) => initial ? data.comments : [...prev, ...data.comments]);
+      setCursor(data.nextCursor);
+      setHasMore(!!data.nextCursor);
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, [presetId, cursor]);
+
+  // Reload from scratch when presetId changes. We deliberately exclude `load`
+  // from deps — its identity changes whenever cursor updates after a fetch,
+  // and re-running this effect on every cursor flip would infinitely re-load.
+  useEffect(() => { load(true); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [presetId]);
+
+  // Each mutation throws on non-OK so CommentForm can keep the user's text.
+  // The parent catches and surfaces the right toast for the status.
   async function postTop(body: string) {
     const res = await fetch(`/api/presets/${presetId}/comments`, {
       method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ body }),
     });
-    if (res.ok) { setCursor(null); load(true); } else handleError(res.status);
+    if (!res.ok) { toastForStatus(res.status); throw new Error(`HTTP ${res.status}`); }
+    load(true);
   }
 
   async function postReply(parentId: string, body: string) {
@@ -49,7 +75,8 @@ export function CommentSection({ presetId, currentUserId, isVerified, isAdmin }:
       method: 'POST', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ body }),
     });
-    if (res.ok) { setCursor(null); load(true); } else handleError(res.status);
+    if (!res.ok) { toastForStatus(res.status); throw new Error(`HTTP ${res.status}`); }
+    load(true);
   }
 
   async function edit(id: string, body: string) {
@@ -57,18 +84,20 @@ export function CommentSection({ presetId, currentUserId, isVerified, isAdmin }:
       method: 'PATCH', headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ body }),
     });
-    if (res.ok) { setCursor(null); load(true); } else handleError(res.status);
+    if (!res.ok) { toastForStatus(res.status); throw new Error(`HTTP ${res.status}`); }
+    load(true);
   }
 
   async function del(id: string) {
     const res = await fetch(`/api/comments/${id}`, { method: 'DELETE' });
-    if (res.ok) { setCursor(null); load(true); } else handleError(res.status);
+    if (!res.ok) { toastForStatus(res.status); return; }
+    load(true);
   }
 
   return (
     <section className="mt-8">
       <h3 className="font-mono-display text-sm uppercase tracking-widest mb-3" style={{ color: 'var(--text-secondary)' }}>
-        Comments
+        {t('heading')}
       </h3>
 
       {!currentUserId ? (
@@ -81,7 +110,7 @@ export function CommentSection({ presetId, currentUserId, isVerified, isAdmin }:
         <CommentForm presetId={presetId} onSubmit={postTop} />
       ) : (
         <p className="text-sm mb-3" style={{ color: 'var(--text-muted)' }}>
-          Email verification required to comment.
+          {t('verifyRequired')}
         </p>
       )}
 

--- a/src/lib/commentSerializer.ts
+++ b/src/lib/commentSerializer.ts
@@ -1,0 +1,29 @@
+// Shared between POST/GET/PATCH/Reply comment routes and the admin moderation
+// endpoint. Single source of truth for which User fields are exposed alongside
+// a comment and how `avatarKey` is rewritten to a stable `/api/avatar/` URL.
+
+export const commentUserSelect = {
+  id: true,
+  username: true,
+  avatarKey: true,
+} as const;
+
+export interface CommentUserRow {
+  id: string;
+  username: string;
+  avatarKey: string | null;
+}
+
+export interface SerializedCommentUser {
+  id: string;
+  username: string;
+  avatarUrl: string | null;
+}
+
+export function serializeCommentUser(u: CommentUserRow): SerializedCommentUser {
+  return {
+    id: u.id,
+    username: u.username,
+    avatarUrl: u.avatarKey ? `/api/avatar/${u.avatarKey}` : null,
+  };
+}

--- a/src/lib/featuredPreset.ts
+++ b/src/lib/featuredPreset.ts
@@ -1,7 +1,12 @@
 import { prisma } from './prisma';
 import type { Prisma } from '@prisma/client';
 
-const M = 5;
+// Bayesian prior parameters. m = "how many votes a preset needs before its own
+// average dominates the global prior". m=10 means a preset with 1×5★ scores
+// (4*10+5)/11 ≈ 4.09, only marginally above the prior — strong sybil-dampening
+// for newly-uploaded presets. m=5 (initial value) was too generous and let a
+// single 5★ accomplice rating push an unproven preset onto the homepage.
+const M = 10;
 const FALLBACK_C = 4.0;
 const WINDOW_DAYS = 30;
 

--- a/tests/unit/api/comments-create.test.ts
+++ b/tests/unit/api/comments-create.test.ts
@@ -27,12 +27,12 @@ function makeRequest(body: unknown, headers: Record<string,string> = {}) {
 
 beforeEach(() => {
   vi.mocked(requireVerifiedUser).mockResolvedValue({ user: { id: 'u1' } as never, session: {} as never });
-  vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: true } as never);
+  vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: true, flagged: false } as never);
+  vi.mocked(prisma.comment.create).mockResolvedValue({ id: 'c1', body: 'hi', user: { id: 'u1', username: 'a', avatarKey: null } } as never);
 });
 
 describe('POST /api/presets/[id]/comments', () => {
   it('creates top-level comment for verified user', async () => {
-    vi.mocked(prisma.comment.create).mockResolvedValue({ id: 'c1', body: 'hi' } as never);
     const res = await POST(makeRequest({ body: 'hi' }), { params: Promise.resolve({ id: 'p1' }) });
     expect(res.status).toBe(200);
     expect(prisma.comment.create).toHaveBeenCalledWith(expect.objectContaining({
@@ -64,7 +64,13 @@ describe('POST /api/presets/[id]/comments', () => {
   });
 
   it('returns 404 for non-public preset', async () => {
-    vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: false } as never);
+    vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: false, flagged: false } as never);
+    const res = await POST(makeRequest({ body: 'hi' }), { params: Promise.resolve({ id: 'p1' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for flagged preset', async () => {
+    vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: true, flagged: true } as never);
     const res = await POST(makeRequest({ body: 'hi' }), { params: Promise.resolve({ id: 'p1' }) });
     expect(res.status).toBe(404);
   });

--- a/tests/unit/api/comments-edit.test.ts
+++ b/tests/unit/api/comments-edit.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => vi.clearAllMocks());
 describe('PATCH /api/comments/[id]', () => {
   it('updates body and sets editedAt for author', async () => {
     vi.mocked(prisma.comment.findUnique).mockResolvedValue({ id: 'c1', userId: 'u1', deletedAt: null } as never);
-    vi.mocked(prisma.comment.update).mockResolvedValue({ id: 'c1', body: 'new', editedAt: new Date() } as never);
+    vi.mocked(prisma.comment.update).mockResolvedValue({ id: 'c1', body: 'new', editedAt: new Date(), user: { id: 'u1', username: 'a', avatarKey: null } } as never);
     const res = await PATCH(req({ body: 'new' }), { params: Promise.resolve({ id: 'c1' }) });
     expect(res.status).toBe(200);
     expect(prisma.comment.update).toHaveBeenCalledWith(expect.objectContaining({

--- a/tests/unit/api/comments-list.test.ts
+++ b/tests/unit/api/comments-list.test.ts
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/prisma', () => ({
-  prisma: { comment: { findMany: vi.fn() } },
+  prisma: {
+    comment: { findMany: vi.fn() },
+    preset: { findUnique: vi.fn() },
+  },
 }));
 
 import { GET } from '@/app/api/presets/[id]/comments/route';
 import { prisma } from '@/lib/prisma';
 
-beforeEach(() => { vi.clearAllMocks(); });
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: true, flagged: false } as never);
+});
 
 function makeReq(url = 'http://test/api/presets/p1/comments') {
   return new NextRequest(url);
@@ -55,5 +61,23 @@ describe('GET /api/presets/[id]/comments', () => {
     const res = await GET(makeReq(), { params: Promise.resolve({ id: 'p1' }) });
     const data = await res.json();
     expect(data.nextCursor).toBeNull();
+  });
+
+  it('returns 404 when preset is non-public (post un-publish)', async () => {
+    vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: false, flagged: false } as never);
+    const res = await GET(makeReq(), { params: Promise.resolve({ id: 'p1' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when preset is flagged', async () => {
+    vi.mocked(prisma.preset.findUnique).mockResolvedValue({ id: 'p1', public: true, flagged: true } as never);
+    const res = await GET(makeReq(), { params: Promise.resolve({ id: 'p1' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when preset does not exist', async () => {
+    vi.mocked(prisma.preset.findUnique).mockResolvedValue(null);
+    const res = await GET(makeReq(), { params: Promise.resolve({ id: 'p1' }) });
+    expect(res.status).toBe(404);
   });
 });

--- a/tests/unit/api/comments-reply.test.ts
+++ b/tests/unit/api/comments-reply.test.ts
@@ -21,12 +21,21 @@ function req(body: unknown) {
   });
 }
 
+// Shapes match the route's `findUnique({ select: { ..., preset: { ... } } })`.
+const VALID_PARENT = {
+  id: 'c1',
+  parentId: null,
+  presetId: 'p1',
+  preset: { public: true, flagged: false },
+};
+const NEW_REPLY = { id: 'r1', user: { id: 'u1', username: 'a', avatarKey: null } };
+
 beforeEach(() => vi.clearAllMocks());
 
 describe('POST /api/comments/[id]/reply', () => {
   it('creates reply to top-level comment', async () => {
-    vi.mocked(prisma.comment.findUnique).mockResolvedValue({ id: 'c1', parentId: null, presetId: 'p1' } as never);
-    vi.mocked(prisma.comment.create).mockResolvedValue({ id: 'r1' } as never);
+    vi.mocked(prisma.comment.findUnique).mockResolvedValue(VALID_PARENT as never);
+    vi.mocked(prisma.comment.create).mockResolvedValue(NEW_REPLY as never);
     const res = await POST(req({ body: 'reply text' }), { params: Promise.resolve({ id: 'c1' }) });
     expect(res.status).toBe(200);
     expect(prisma.comment.create).toHaveBeenCalledWith(expect.objectContaining({
@@ -35,20 +44,38 @@ describe('POST /api/comments/[id]/reply', () => {
   });
 
   it('rejects reply to reply (400)', async () => {
-    vi.mocked(prisma.comment.findUnique).mockResolvedValue({ id: 'c1', parentId: 'c0', presetId: 'p1' } as never);
+    vi.mocked(prisma.comment.findUnique).mockResolvedValue({ ...VALID_PARENT, parentId: 'c0' } as never);
     const res = await POST(req({ body: 'x' }), { params: Promise.resolve({ id: 'c1' }) });
     expect(res.status).toBe(400);
   });
 
   it('allows reply to soft-deleted parent', async () => {
-    vi.mocked(prisma.comment.findUnique).mockResolvedValue({ id: 'c1', parentId: null, presetId: 'p1', deletedAt: new Date() } as never);
-    vi.mocked(prisma.comment.create).mockResolvedValue({ id: 'r1' } as never);
+    vi.mocked(prisma.comment.findUnique).mockResolvedValue({ ...VALID_PARENT, deletedAt: new Date() } as never);
+    vi.mocked(prisma.comment.create).mockResolvedValue(NEW_REPLY as never);
     const res = await POST(req({ body: 'x' }), { params: Promise.resolve({ id: 'c1' }) });
     expect(res.status).toBe(200);
   });
 
   it('returns 404 when parent missing', async () => {
     vi.mocked(prisma.comment.findUnique).mockResolvedValue(null);
+    const res = await POST(req({ body: 'x' }), { params: Promise.resolve({ id: 'c1' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when preset has been un-published', async () => {
+    vi.mocked(prisma.comment.findUnique).mockResolvedValue({
+      ...VALID_PARENT,
+      preset: { public: false, flagged: false },
+    } as never);
+    const res = await POST(req({ body: 'x' }), { params: Promise.resolve({ id: 'c1' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when preset is flagged', async () => {
+    vi.mocked(prisma.comment.findUnique).mockResolvedValue({
+      ...VALID_PARENT,
+      preset: { public: true, flagged: true },
+    } as never);
     const res = await POST(req({ body: 'x' }), { params: Promise.resolve({ id: 'c1' }) });
     expect(res.status).toBe(404);
   });

--- a/tests/unit/lib/featuredPreset.test.ts
+++ b/tests/unit/lib/featuredPreset.test.ts
@@ -11,6 +11,11 @@ describe('computeBayesScore', () => {
   it('zero ratings returns C', () => {
     expect(computeBayesScore({ ratingAverage: 0, ratingCount: 0 }, 4, 5)).toBe(4);
   });
+  it('default m=10 dampens single 5★ outliers: 1×5★ with C=4 → 4.09', () => {
+    // Sybil-dampening: a single accomplice rating shouldn't push a fresh
+    // preset past presets with established rating history.
+    expect(computeBayesScore({ ratingAverage: 5, ratingCount: 1 }, 4)).toBeCloseTo(4.09, 2);
+  });
 });
 
 vi.mock('@/lib/prisma', () => ({


### PR DESCRIPTION
## Summary

Follow-up to PR #72. Two parallel deep reviews (security + code quality) flagged 26 findings; this PR fixes all MEDIUM and IMPORTANT ones plus a few quick LOWs.

## Security (MEDIUM)

- **Comments leak after un-publish** — `GET /api/presets/[id]/comments` now returns 404 when the preset is non-public or flagged. POST top-level + Reply gained the same gate; Reply previously checked neither.
- **Bayes m=10** — single 5★ from accomplice account no longer pushes a fresh preset onto the homepage Featured slot.

## User-facing UX (IMPORTANT)

- Rating optimistic-UI rolls back on POST failure; previously left a phantom score forever.
- CommentForm keeps the textarea content on 429 / auth fail so users can retry.
- CommentSection now toasts 401/403/5xx (was 429-only).
- Gallery cards show correct existingRating on every page (was 0 after page 1 → corrupted count on re-rate).
- AdminCommentsTab gained Load-More — past row 50 was previously unreachable.
- Confirm dialog before user soft-delete (soft-delete nulls body and is not reversible).

## Hardening + cleanup

- Shared `commentSerializer` — PATCH no longer returns raw `avatarKey` while POST/GET return `avatarUrl`.
- 3 hardcoded English strings now i18n'd in 6 locales (`comments.heading`, `comments.verifyRequired`, `admin.comments.cancel`/`loadMore`).
- New keys for `comments.authToast`, `comments.genericError`, `gallery.rate.errorTooltip`.
- Removed dead key `comments.adminDeleteReasonLabel` (admin tab uses `admin.comments.hardDeleteReasonLabel`).
- New migration: `Comment(createdAt DESC)` for admin moderation list.

## Test plan

- [x] 665/665 unit + component tests green (up from 655 — added cases for un-published GET 404, flagged GET 404, flagged Reply 404, Bayes m=10 default).
- [x] `npm run ci` green in 42s.
- [x] Typecheck clean.
- [ ] Manual smoke on prod after deploy (un-publish a preset → confirm GET comments 404).

## Deferred (LOW, acknowledged)

- Featured-block: pre-fetch comments in parallel via `Promise.all` (minor perf)
- Hard-delete count race (audit log imprecision under concurrent reply)
- Featured query top-N stub (only matters at 10k+ candidates)
- Soft-delete CHECK constraint (defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)