### PR TITLE
feat(error-logger): fingerprint grouping + critical-email alerts (closes #70)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -534,6 +534,8 @@
       "unflag": "Markierung entfernen",
       "createIssue": "GH Issue erstellen",
       "copy": "Kopieren",
+      "resolve": "Erledigt",
+      "unresolve": "Wieder öffnen",
       "deleteAll": "Alle löschen"
     },
     "badges": {
@@ -701,5 +703,10 @@
       "notAuthorized": "Nur der Preset-Owner kann Audio hochladen",
       "genericError": "Upload fehlgeschlagen — bitte erneut versuchen"
     }
+  },
+  "error": {
+    "title": "Da ist etwas schiefgegangen",
+    "body": "Wir haben den Fehler automatisch protokolliert. Versuch es erneut oder kehre zur Startseite zurück.",
+    "retry": "Erneut versuchen"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -300,7 +300,9 @@
       "ownPresetTooltip": "Cannot rate your own preset",
       "errorTooltip": "Rating failed — try again"
     },
-    "audio": { "iconLabel": "Play preview" }
+    "audio": {
+      "iconLabel": "Play preview"
+    }
   },
   "device": {
     "connect": "Connect GP-200",
@@ -532,6 +534,8 @@
       "unflag": "Unflag",
       "createIssue": "Create GH Issue",
       "copy": "Copy",
+      "resolve": "Resolve",
+      "unresolve": "Reopen",
       "deleteAll": "Delete all"
     },
     "badges": {
@@ -699,5 +703,10 @@
       "notAuthorized": "Only the preset owner can upload audio",
       "genericError": "Upload failed — please try again"
     }
+  },
+  "error": {
+    "title": "Something went wrong",
+    "body": "We logged the error automatically. Try again, or head back to the homepage.",
+    "retry": "Try again"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -534,6 +534,8 @@
       "unflag": "Desmarcar",
       "createIssue": "Crear GH Issue",
       "copy": "Copiar",
+      "resolve": "Resolver",
+      "unresolve": "Reabrir",
       "deleteAll": "Eliminar todo"
     },
     "badges": {
@@ -701,5 +703,10 @@
       "notAuthorized": "Solo el propietario del preset puede subir audio",
       "genericError": "Fallo al subir — inténtalo de nuevo"
     }
+  },
+  "error": {
+    "title": "Algo salió mal",
+    "body": "Hemos registrado el error automáticamente. Inténtalo de nuevo o vuelve a la página de inicio.",
+    "retry": "Reintentar"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -534,6 +534,8 @@
       "unflag": "Retirer le signalement",
       "createIssue": "Créer un ticket GH",
       "copy": "Copier",
+      "resolve": "Résoudre",
+      "unresolve": "Rouvrir",
       "deleteAll": "Tout supprimer"
     },
     "badges": {
@@ -701,5 +703,10 @@
       "notAuthorized": "Seul le propriétaire du preset peut téléverser l'audio",
       "genericError": "Échec — réessaie"
     }
+  },
+  "error": {
+    "title": "Une erreur est survenue",
+    "body": "Nous avons enregistré l’erreur automatiquement. Réessaie ou retourne à l’accueil.",
+    "retry": "Réessayer"
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -534,6 +534,8 @@
       "unflag": "Rimuovi segnalazione",
       "createIssue": "Crea GH Issue",
       "copy": "Copia",
+      "resolve": "Risolvi",
+      "unresolve": "Riapri",
       "deleteAll": "Elimina tutti"
     },
     "badges": {
@@ -701,5 +703,10 @@
       "notAuthorized": "Solo il proprietario del preset può caricare l'audio",
       "genericError": "Caricamento fallito — riprova"
     }
+  },
+  "error": {
+    "title": "Qualcosa è andato storto",
+    "body": "Abbiamo registrato l'errore automaticamente. Riprova oppure torna alla home.",
+    "retry": "Riprova"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -534,6 +534,8 @@
       "unflag": "Remover sinalização",
       "createIssue": "Criar GH Issue",
       "copy": "Copiar",
+      "resolve": "Resolver",
+      "unresolve": "Reabrir",
       "deleteAll": "Excluir tudo"
     },
     "badges": {
@@ -701,5 +703,10 @@
       "notAuthorized": "Apenas o dono do preset pode enviar áudio",
       "genericError": "Falha no envio — tente novamente"
     }
+  },
+  "error": {
+    "title": "Algo deu errado",
+    "body": "Registramos o erro automaticamente. Tente novamente ou volte à página inicial.",
+    "retry": "Tentar novamente"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -534,6 +534,8 @@
       "unflag": "Remover sinalização",
       "createIssue": "Criar GH Issue",
       "copy": "Copiar",
+      "resolve": "Resolver",
+      "unresolve": "Reabrir",
       "deleteAll": "Eliminar tudo"
     },
     "badges": {
@@ -701,5 +703,10 @@
       "notAuthorized": "Apenas o dono do preset pode carregar áudio",
       "genericError": "Falha no envio — tente novamente"
     }
+  },
+  "error": {
+    "title": "Algo correu mal",
+    "body": "Registámos o erro automaticamente. Tente novamente ou volte à página inicial.",
+    "retry": "Tentar novamente"
   }
 }

--- a/prisma/migrations/20260522092405_error_log_v2_fingerprint_grouping/migration.sql
+++ b/prisma/migrations/20260522092405_error_log_v2_fingerprint_grouping/migration.sql
@@ -1,0 +1,48 @@
+-- ErrorLog v2: fingerprint-based grouping + severity + per-fingerprint email throttle.
+--
+-- Strategy:
+--   1) Add new columns as nullable / with defaults so existing rows survive.
+--   2) Backfill: legacy rows get category='legacy', severity mapped from old level,
+--      fingerprint from md5(category|message). Built-in md5 is fine for legacy
+--      bucketing because legacy rows can never collide with new rows (different
+--      category prefix), and the format matches the 32-hex-char shape the
+--      application logger will produce going forward.
+--   3) Tighten new columns to NOT NULL, drop the old `level` column.
+--   4) Add indexes.
+
+-- 1) Add new columns
+ALTER TABLE "ErrorLog"
+  ADD COLUMN "fingerprint"   TEXT,
+  ADD COLUMN "category"      TEXT,
+  ADD COLUMN "severity"      TEXT,
+  ADD COLUMN "route"         TEXT,
+  ADD COLUMN "method"        TEXT,
+  ADD COLUMN "ip"            TEXT,
+  ADD COLUMN "count"         INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN "firstSeenAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "lastSeenAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "resolvedAt"    TIMESTAMP(3),
+  ADD COLUMN "lastEmailedAt" TIMESTAMP(3);
+
+-- 2) Backfill from old `level` column
+UPDATE "ErrorLog"
+SET
+  "category"    = 'legacy',
+  "severity"    = CASE WHEN "level" = 'warn' THEN 'warning' ELSE 'error' END,
+  "fingerprint" = substring(md5('legacy|' || "message"), 1, 32),
+  "firstSeenAt" = "createdAt",
+  "lastSeenAt"  = "createdAt"
+WHERE "fingerprint" IS NULL;
+
+-- 3) Tighten constraints + drop old column
+ALTER TABLE "ErrorLog"
+  ALTER COLUMN "fingerprint" SET NOT NULL,
+  ALTER COLUMN "category"    SET NOT NULL,
+  ALTER COLUMN "severity"    SET NOT NULL;
+
+ALTER TABLE "ErrorLog" DROP COLUMN "level";
+
+-- 4) Indexes
+CREATE INDEX "ErrorLog_fingerprint_idx"            ON "ErrorLog"("fingerprint");
+CREATE INDEX "ErrorLog_severity_resolvedAt_idx"    ON "ErrorLog"("severity", "resolvedAt");
+CREATE INDEX "ErrorLog_lastSeenAt_idx"             ON "ErrorLog"("lastSeenAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -154,15 +154,32 @@ model Comment {
 }
 
 model ErrorLog {
-  id        String   @id @default(cuid())
-  level     String   // "error" | "warn"
-  message   String
-  stack     String?
-  url       String?
-  userId    String?
-  metadata  Json?
-  createdAt DateTime @default(now())
+  id            String    @id @default(cuid())
+  // 32-char hex (SHA-256 of category|message, truncated) — groups identical errors.
+  fingerprint   String
+  // Bucket: api | client | auth | db | s3 | external | validation | rate_limit | legacy
+  category      String
+  // critical | error | warning | info  (was: level)
+  severity      String
+  message       String
+  stack         String?   @db.Text
+  route         String?
+  method        String?
+  url           String?
+  userId        String?
+  ip            String?
+  metadata      Json?
+  count         Int       @default(1)
+  firstSeenAt   DateTime  @default(now())
+  lastSeenAt    DateTime  @default(now())
+  resolvedAt    DateTime?
+  // Throttle critical-email sends per fingerprint (1/hour).
+  lastEmailedAt DateTime?
+  createdAt     DateTime  @default(now())
 
+  @@index([fingerprint])
+  @@index([severity, resolvedAt])
+  @@index([lastSeenAt])
   @@index([createdAt])
 }
 

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+
+// App-Router error boundary. Fires on any uncaught render error in this
+// locale's tree. Posts to /api/errors/client so the same /admin/errors dashboard
+// shows both server- and client-side failures.
+
+export default function ErrorBoundary({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations('error');
+
+  useEffect(() => {
+    // Fire-and-forget. We do NOT block the UI on reporting, and we do NOT show
+    // the user whether reporting succeeded — they care about recovery, not
+    // observability plumbing.
+    fetch('/api/errors/client', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message || 'unknown client error',
+        stack: error.stack,
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        metadata: { digest: error.digest ?? null },
+      }),
+    }).catch(() => {
+      // intentional: never throw from inside the error boundary's effect
+    });
+  }, [error]);
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-16">
+      <h1
+        className="font-mono-display text-2xl font-bold tracking-tight mb-4"
+        style={{ color: 'var(--accent-amber)' }}
+      >
+        {t('title')}
+      </h1>
+      <p className="text-sm mb-6" style={{ color: 'var(--text-secondary)' }}>
+        {t('body')}
+      </p>
+      <button
+        onClick={reset}
+        className="px-6 py-2.5 rounded font-mono-display text-sm font-bold tracking-wider uppercase border transition-colors"
+        style={{
+          color: 'var(--accent-amber)',
+          borderColor: 'var(--accent-amber)',
+          background: 'var(--glow-amber)',
+        }}
+      >
+        {t('retry')}
+      </button>
+    </div>
+  );
+}

--- a/src/app/api/admin/errors/[id]/route.ts
+++ b/src/app/api/admin/errors/[id]/route.ts
@@ -18,7 +18,13 @@ export const DELETE = withAdminAuth<{ id: string }>(async (_request, { params, a
       action: 'DELETE_ERROR_LOG',
       targetType: 'user',
       targetId: admin.id,
-      metadata: { errorId: id, level: error.level, message: error.message.slice(0, 120) },
+      metadata: {
+        errorId: id,
+        severity: error.severity,
+        category: error.category,
+        fingerprint: error.fingerprint,
+        message: error.message.slice(0, 120),
+      },
     });
   } catch {
     // non-fatal

--- a/src/app/api/admin/errors/route.ts
+++ b/src/app/api/admin/errors/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { withAdminAuth } from '@/lib/withAdminAuth';
-import { adminErrorsQuerySchema } from '@/lib/validators.admin';
+import { adminErrorsQuerySchema, adminErrorsPatchSchema } from '@/lib/validators.admin';
 import { logAdminAction } from '@/lib/admin';
 
 export const GET = withAdminAuth(async (request) => {
@@ -11,44 +11,104 @@ export const GET = withAdminAuth(async (request) => {
     return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
   }
 
-  const { q, level, page, limit } = parsed.data;
+  const { q, severity, category, resolved, page, limit } = parsed.data;
 
   const where: Record<string, unknown> = {};
   if (q) where.message = { contains: q, mode: 'insensitive' };
-  if (level) where.level = level;
+  if (severity) where.severity = severity;
+  if (category) where.category = category;
+  if (resolved === 'true') where.resolvedAt = { not: null };
+  else if (resolved === 'false') where.resolvedAt = null;
 
-  const [errors, total] = await Promise.all([
+  // Sorted by severity (critical > error > warning > info) then most-recent
+  // occurrence first. severity is a string column so we sort it client-side
+  // after fetch — server-side ORDER BY CASE WHEN ... would beat the indexes.
+  const [errors, total, unresolvedCounts] = await Promise.all([
     prisma.errorLog.findMany({
       where,
-      orderBy: { createdAt: 'desc' },
+      orderBy: { lastSeenAt: 'desc' },
       skip: (page - 1) * limit,
       take: limit,
     }),
     prisma.errorLog.count({ where }),
+    // Sidebar badge data: unresolved counts by severity, independent of filters.
+    prisma.errorLog.groupBy({
+      by: ['severity'],
+      where: { resolvedAt: null },
+      _count: { _all: true },
+    }),
   ]);
 
+  const severityRank: Record<string, number> = { critical: 0, error: 1, warning: 2, info: 3 };
+  const sorted = errors.slice().sort((a, b) => {
+    const r = (severityRank[a.severity] ?? 99) - (severityRank[b.severity] ?? 99);
+    if (r !== 0) return r;
+    return b.lastSeenAt.getTime() - a.lastSeenAt.getTime();
+  });
+
   return NextResponse.json({
-    errors: errors.map((e) => ({
+    errors: sorted.map((e) => ({
       id: e.id,
-      level: e.level,
+      fingerprint: e.fingerprint,
+      category: e.category,
+      severity: e.severity,
       message: e.message,
       stack: e.stack,
+      route: e.route,
+      method: e.method,
       url: e.url,
       userId: e.userId,
+      ip: e.ip,
       metadata: e.metadata,
+      count: e.count,
+      firstSeenAt: e.firstSeenAt.toISOString(),
+      lastSeenAt: e.lastSeenAt.toISOString(),
+      resolvedAt: e.resolvedAt?.toISOString() ?? null,
       createdAt: e.createdAt.toISOString(),
     })),
     total,
     page,
     limit,
+    unresolvedCounts: Object.fromEntries(
+      unresolvedCounts.map((row) => [row.severity, row._count._all]),
+    ),
   });
 }, { csrf: false });
 
+export const PATCH = withAdminAuth(async (request, { admin }) => {
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const parsed = adminErrorsPatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const { fingerprint, ids, resolved } = parsed.data;
+
+  // Resolve by fingerprint (groups every row sharing the same hash) or by
+  // explicit id list. fingerprint is the common case from the UI; ids is for
+  // ad-hoc selection.
+  const where = fingerprint ? { fingerprint } : { id: { in: ids! } };
+  const { count } = await prisma.errorLog.updateMany({
+    where,
+    data: { resolvedAt: resolved ? new Date() : null },
+  });
+
+  try {
+    await logAdminAction({
+      adminId: admin.id,
+      action: resolved ? 'RESOLVE_ERROR' : 'UNRESOLVE_ERROR',
+      targetType: 'user',
+      targetId: admin.id,
+      metadata: { fingerprint, ids, count },
+    });
+  } catch {
+    // ignore audit failure
+  }
+
+  return NextResponse.json({ success: true, count });
+});
+
 export const DELETE = withAdminAuth(async (_request, { admin }) => {
   const { count } = await prisma.errorLog.deleteMany();
-  // Audit-trail: record the purge against the acting admin's own ID so an
-  // admin wiping forensic data can't hide it. Non-fatal on failure — the
-  // primary action already succeeded.
   try {
     await logAdminAction({
       adminId: admin.id,

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -4,13 +4,30 @@ import { withAdminAuth } from '@/lib/withAdminAuth';
 
 export const GET = withAdminAuth(
   async () => {
-    const [users, presets, errors, suspended] = await Promise.all([
-      prisma.user.count(),
-      prisma.preset.count(),
-      prisma.errorLog.count(),
-      prisma.user.count({ where: { suspended: true } }),
-    ]);
-    return NextResponse.json({ users, presets, errors, suspended });
+    // Renamed from {users, presets, errors, suspended} → {userCount, ...} to
+    // match what the AdminDashboard + Navbar have always been reading. The
+    // old keys produced a silently-broken badge for months; this is the fix.
+    //
+    // unresolvedCritical/unresolvedError feed the sidebar severity badge from
+    // issue #70 — only unresolved rows count, so resolving a fingerprint
+    // immediately clears the badge.
+    const [userCount, presetCount, errorCount, suspendedCount, unresolvedCritical, unresolvedError] =
+      await Promise.all([
+        prisma.user.count(),
+        prisma.preset.count(),
+        prisma.errorLog.count(),
+        prisma.user.count({ where: { suspended: true } }),
+        prisma.errorLog.count({ where: { severity: 'critical', resolvedAt: null } }),
+        prisma.errorLog.count({ where: { severity: 'error', resolvedAt: null } }),
+      ]);
+    return NextResponse.json({
+      userCount,
+      presetCount,
+      errorCount,
+      suspendedCount,
+      unresolvedCritical,
+      unresolvedError,
+    });
   },
   { csrf: false },
 );

--- a/src/app/api/errors/client/route.ts
+++ b/src/app/api/errors/client/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { logError } from '@/lib/errorLog';
+import { rateLimit } from '@/lib/rateLimit';
+import { validateSession } from '@/lib/session';
+
+// Surface uncaught client-side render errors to the same observability pipeline
+// as server errors. Reported by src/app/[locale]/error.tsx (App-Router error
+// boundary). Anonymous reports allowed; userId attached when a session exists.
+
+const bodySchema = z.object({
+  message: z.string().min(1).max(500),
+  stack: z.string().max(8000).optional(),
+  url: z.string().max(500).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+function clientIp(req: NextRequest): string | null {
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0]?.trim() ?? null;
+  return req.headers.get('x-real-ip');
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const ip = clientIp(req);
+  // Hard ceiling on client-side error volume per IP — without this, a misbehaving
+  // tab in a loop could flood the table. Generous enough to survive a real
+  // outage (when many users genuinely hit errors at once).
+  const { allowed } = rateLimit(`client-error:${ip ?? 'anon'}`, 30, 60_000);
+  if (!allowed) return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+
+  const { user } = await validateSession();
+
+  await logError({
+    message: parsed.data.message,
+    stack: parsed.data.stack,
+    url: parsed.data.url,
+    metadata: parsed.data.metadata,
+    category: 'client',
+    severity: 'error',
+    userId: user?.id,
+    ip: ip ?? undefined,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -11,13 +11,39 @@ type Tab = 'users' | 'presets' | 'errors' | 'auditLog' | 'comments';
 interface Stats { userCount: number; presetCount: number; errorCount: number; suspendedCount: number; }
 interface AdminUser { id: string; username: string; email: string; role: string; suspended: boolean; avatarUrl: string | null; createdAt: string; presetCount: number; }
 interface AdminPreset { id: string; name: string; author: string | null; style: string | null; public: boolean; flagged: boolean; modules: string[]; downloadCount: number; ratingAverage: number; createdAt: string; ownerUsername: string; }
-interface ErrorEntry { id: string; level: string; message: string; stack: string | null; url: string | null; userId: string | null; metadata: unknown; createdAt: string; }
+interface ErrorEntry {
+  id: string;
+  fingerprint: string;
+  category: string;
+  severity: string;
+  message: string;
+  stack: string | null;
+  route: string | null;
+  method: string | null;
+  url: string | null;
+  userId: string | null;
+  ip: string | null;
+  metadata: unknown;
+  count: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  resolvedAt: string | null;
+  createdAt: string;
+}
 interface AuditEntry { id: string; adminUsername: string; action: string; targetType: string; targetId: string; reason: string | null; metadata: unknown; createdAt: string; }
 
+const SEVERITY_COLORS: Record<string, { color: string; bg: string }> = {
+  critical: { color: '#ef4444', bg: 'rgba(239,68,68,0.18)' },
+  error:    { color: '#f97316', bg: 'rgba(249,115,22,0.14)' },
+  warning:  { color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
+  info:     { color: '#60a5fa', bg: 'rgba(96,165,250,0.12)' },
+};
+
 function buildGhIssueUrl(error: ErrorEntry): string {
-  const title = encodeURIComponent(`[Bug] ${error.message}${error.url ? ` in ${error.url}` : ''}`);
+  const where = error.route ?? error.url ?? '';
+  const title = encodeURIComponent(`[Bug] ${error.message}${where ? ` in ${where}` : ''}`);
   const body = encodeURIComponent(
-    `## Error Details\n- **Message:** ${error.message}\n- **Route:** ${error.url ?? 'N/A'}\n- **Time:** ${error.createdAt}\n- **User:** ${error.userId ?? 'N/A'}\n\n` +
+    `## Error Details\n- **Severity:** ${error.severity}\n- **Category:** ${error.category}\n- **Fingerprint:** ${error.fingerprint.slice(0, 8)}\n- **Occurrences:** ${error.count}\n- **Message:** ${error.message}\n- **Route:** ${error.route ?? error.url ?? 'N/A'}\n- **First seen:** ${error.firstSeenAt}\n- **Last seen:** ${error.lastSeenAt}\n- **User:** ${error.userId ?? 'N/A'}\n\n` +
     (error.stack ? `## Stack Trace\n\`\`\`\n${error.stack}\n\`\`\`\n\n` : '') +
     (error.metadata ? `## Metadata\n\`\`\`json\n${JSON.stringify(error.metadata, null, 2)}\n\`\`\`\n` : '')
   );
@@ -34,7 +60,8 @@ export function AdminDashboard() {
   const [errors, setErrors] = useState<ErrorEntry[]>([]);
   const [actions, setActions] = useState<AuditEntry[]>([]);
   const [search, setSearch] = useState('');
-  const [levelFilter, setLevelFilter] = useState('');
+  const [severityFilter, setSeverityFilter] = useState('');
+  const [resolvedFilter, setResolvedFilter] = useState<'open' | 'resolved' | 'all'>('open');
   const [flaggedFilter, setFlaggedFilter] = useState(false);
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
@@ -68,10 +95,12 @@ export function AdminDashboard() {
   const fetchErrors = useCallback(() => {
     const params = new URLSearchParams({ page: String(page), limit: String(limit) });
     if (search) params.set('q', search);
-    if (levelFilter) params.set('level', levelFilter);
+    if (severityFilter) params.set('severity', severityFilter);
+    if (resolvedFilter === 'open') params.set('resolved', 'false');
+    else if (resolvedFilter === 'resolved') params.set('resolved', 'true');
     fetch(`/api/admin/errors?${params}`).then((r) => r.ok ? r.json() : null)
       .then((d) => { if (d) { setErrors(d.errors); setTotal(d.total); } }).catch(() => {});
-  }, [page, search, levelFilter]);
+  }, [page, search, severityFilter, resolvedFilter]);
 
   const fetchActions = useCallback(() => {
     const params = new URLSearchParams({ page: String(page), limit: String(limit) });
@@ -83,7 +112,7 @@ export function AdminDashboard() {
 
   useEffect(() => {
     setPage(1);
-  }, [tab, search, levelFilter, flaggedFilter]);
+  }, [tab, search, severityFilter, resolvedFilter, flaggedFilter]);
 
   useEffect(() => {
     if (tab === 'users') fetchUsers();
@@ -129,6 +158,10 @@ export function AdminDashboard() {
   async function handleDeleteAllErrors() {
     if (await adminFetch('/api/admin/errors', 'DELETE')) reload();
     setConfirmAction(null);
+  }
+
+  async function handleResolveError(fingerprint: string, resolved: boolean) {
+    if (await adminFetch('/api/admin/errors', 'PATCH', { fingerprint, resolved })) reload();
   }
 
   async function handleWarnUser(reason: string, message?: string) {
@@ -184,12 +217,21 @@ export function AdminDashboard() {
         )}
         {tab === 'errors' && (
           <>
-            <select value={levelFilter} onChange={(e) => setLevelFilter(e.target.value)}
+            <select value={severityFilter} onChange={(e) => setSeverityFilter(e.target.value)}
               className="px-3 py-2 rounded-lg text-sm"
               style={{ background: 'var(--bg-input, #2a2a2a)', border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)' }}>
               <option value="">{t('allLevels')}</option>
+              <option value="critical">critical</option>
               <option value="error">error</option>
-              <option value="warn">warn</option>
+              <option value="warning">warning</option>
+              <option value="info">info</option>
+            </select>
+            <select value={resolvedFilter} onChange={(e) => setResolvedFilter(e.target.value as 'open' | 'resolved' | 'all')}
+              className="px-3 py-2 rounded-lg text-sm"
+              style={{ background: 'var(--bg-input, #2a2a2a)', border: '1px solid var(--border-subtle)', color: 'var(--text-secondary)' }}>
+              <option value="open">open</option>
+              <option value="resolved">resolved</option>
+              <option value="all">all</option>
             </select>
             <button className={btnClass} style={btnStyle('#ef4444')}
               onClick={() => setConfirmAction({ message: t('confirm.deleteAllErrors'), onConfirm: handleDeleteAllErrors })}>
@@ -286,20 +328,32 @@ export function AdminDashboard() {
       {tab === 'errors' && (
         <div className="space-y-1">
           {errors.length === 0 && <p className="text-sm py-8 text-center" style={{ color: 'var(--text-muted)' }}>{t('noResults')}</p>}
-          {errors.map((err) => (
-            <div key={err.id} style={{ borderBottom: '1px solid var(--border-subtle)' }}>
+          {errors.map((err) => {
+            const sev = SEVERITY_COLORS[err.severity] ?? SEVERITY_COLORS.error;
+            const isResolved = err.resolvedAt !== null;
+            const routeOrUrl = err.route ?? err.url ?? '';
+            return (
+            <div key={err.id} style={{ borderBottom: '1px solid var(--border-subtle)', opacity: isResolved ? 0.55 : 1 }}>
               <div className="flex items-center p-3 cursor-pointer" onClick={() => setExpandedError(expandedError === err.id ? null : err.id)}>
-                <span className="text-[11px] font-mono px-1.5 py-0.5 rounded mr-3"
-                  style={{
-                    color: err.level === 'error' ? '#ef4444' : '#f59e0b',
-                    background: err.level === 'error' ? 'rgba(239,68,68,0.12)' : 'rgba(245,158,11,0.12)',
-                  }}>
-                  {err.level.toUpperCase()}
+                <span className="text-[11px] font-mono px-1.5 py-0.5 rounded mr-3 uppercase"
+                  style={{ color: sev.color, background: sev.bg }}>
+                  {err.severity}
                 </span>
+                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded mr-2"
+                  style={{ color: 'var(--text-muted)', background: 'rgba(255,255,255,0.04)' }}>
+                  {err.category}
+                </span>
+                {err.count > 1 && (
+                  <span className="text-[10px] font-mono px-1.5 py-0.5 rounded mr-2"
+                    style={{ color: 'var(--accent-amber)', background: 'rgba(245,158,11,0.10)' }}
+                    title={`First seen ${new Date(err.firstSeenAt).toLocaleString()}`}>
+                    ×{err.count}
+                  </span>
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-mono truncate" style={{ color: 'var(--text-primary)' }}>{err.message}</div>
                   <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                    {err.url ?? ''} · {err.userId ?? '—'} · {new Date(err.createdAt).toLocaleString()}
+                    {err.fingerprint.slice(0, 8)} · {routeOrUrl} · {err.userId ?? '—'} · {new Date(err.lastSeenAt).toLocaleString()}
                   </div>
                 </div>
                 <span style={{ color: 'var(--text-muted)' }}>{expandedError === err.id ? '▼' : '▶'}</span>
@@ -313,12 +367,16 @@ export function AdminDashboard() {
                       {err.metadata ? `\n--- Metadata ---\n${JSON.stringify(err.metadata, null, 2)}` : null}
                     </pre>
                   )}
-                  <div className="flex gap-2">
+                  <div className="flex gap-2 flex-wrap">
                     <a href={buildGhIssueUrl(err)} target="_blank" rel="noopener noreferrer"
                       className={btnClass + ' flex items-center gap-1.5 no-underline'} style={btnStyle('var(--text-primary)')}>
                       <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                       {t('actions.createIssue')}
                     </a>
+                    <button className={btnClass} style={btnStyle(isResolved ? '#f59e0b' : '#4ec46a')}
+                      onClick={() => handleResolveError(err.fingerprint, !isResolved)}>
+                      {isResolved ? t('actions.unresolve') : t('actions.resolve')}
+                    </button>
                     <button className={btnClass} style={btnStyle('var(--text-secondary)')}
                       onClick={() => navigator.clipboard.writeText(`${err.message}\n${err.stack ?? ''}\n${JSON.stringify(err.metadata)}`)}>
                       {t('actions.copy')}
@@ -331,7 +389,8 @@ export function AdminDashboard() {
                 </div>
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,8 @@ export function Navbar() {
   const [username, setUsername] = useState<string | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [role, setRole] = useState<string | null>(null);
-  const [errorCount, setErrorCount] = useState(0);
+  const [unresolvedCritical, setUnresolvedCritical] = useState(0);
+  const [unresolvedError, setUnresolvedError] = useState(0);
 
   useEffect(() => {
     fetch('/api/profile')
@@ -26,12 +27,20 @@ export function Navbar() {
         if (data?.role === 'ADMIN') {
           fetch('/api/admin/stats')
             .then((r) => (r.ok ? r.json() : null))
-            .then((stats: { errorCount?: number } | null) => setErrorCount(stats?.errorCount ?? 0))
-            .catch(() => setErrorCount(0));
+            .then((stats: { unresolvedCritical?: number; unresolvedError?: number } | null) => {
+              setUnresolvedCritical(stats?.unresolvedCritical ?? 0);
+              setUnresolvedError(stats?.unresolvedError ?? 0);
+            })
+            .catch(() => { setUnresolvedCritical(0); setUnresolvedError(0); });
         }
       })
       .catch(() => { setUsername(null); setRole(null); });
   }, [pathname]);
+
+  // Critical wins visually — red dot with the critical count if any exist,
+  // otherwise an amber dot with the error count. Nothing when both are zero.
+  const badgeCount = unresolvedCritical > 0 ? unresolvedCritical : unresolvedError;
+  const badgeColor = unresolvedCritical > 0 ? '#ef4444' : '#f97316';
 
   async function handleLogout() {
     await fetch('/api/auth/logout', { method: 'POST' });
@@ -162,8 +171,14 @@ export function Navbar() {
             }}
             data-testid="nav-link-admin">
             {t('admin')}
-            {errorCount > 0 && (
-              <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full" style={{ background: '#ef4444' }} />
+            {badgeCount > 0 && (
+              <span
+                className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 px-1 rounded-full flex items-center justify-center font-mono-display text-[9px] font-bold leading-none"
+                style={{ background: badgeColor, color: '#fff' }}
+                title={`${unresolvedCritical} critical · ${unresolvedError} error (unresolved)`}
+              >
+                {badgeCount > 99 ? '99+' : badgeCount}
+              </span>
             )}
           </Link>
         )}
@@ -204,8 +219,13 @@ export function Navbar() {
               className="transition-colors hover:text-[var(--accent-amber)] relative"
               style={{ color: pathname === '/admin' ? 'var(--accent-amber)' : 'var(--text-secondary)' }}>
               {t('admin')}
-              {errorCount > 0 && (
-                <span className="inline-block w-2 h-2 rounded-full ml-1" style={{ background: '#ef4444' }} />
+              {badgeCount > 0 && (
+                <span
+                  className="inline-block min-w-[16px] h-4 px-1 rounded-full ml-2 font-mono-display text-[9px] font-bold leading-none text-center"
+                  style={{ background: badgeColor, color: '#fff', lineHeight: '16px' }}
+                >
+                  {badgeCount > 99 ? '99+' : badgeCount}
+                </span>
               )}
             </Link>
           )}

--- a/src/lib/criticalErrorEmail.ts
+++ b/src/lib/criticalErrorEmail.ts
@@ -1,0 +1,88 @@
+import nodemailer from 'nodemailer';
+
+// Plain-text critical-error mail to ADMIN_EMAIL. Intentionally bypasses the
+// localized template stack used for user-facing mail: this goes to one person
+// (the operator), needs to be parseable at 3am, and must not block on i18n.
+//
+// Shares SMTP config with src/lib/email.ts but uses its own transporter so the
+// admin-alert path stays independent of any nodemailer pool issues in the user
+// mail path.
+
+type CachedTransporter = ReturnType<typeof nodemailer.createTransport>;
+let _transporter: CachedTransporter | null = null;
+
+function getTransporter(): CachedTransporter {
+  if (_transporter) return _transporter;
+  const host = process.env.MAIL_HOST ?? process.env.EMAIL_SMTP_HOST;
+  const port = Number(process.env.MAIL_PORT ?? process.env.EMAIL_SMTP_PORT ?? 1025);
+  const user = process.env.MAIL_USERNAME ?? process.env.EMAIL_SMTP_USER;
+  const pass = process.env.MAIL_PASSWORD ?? process.env.EMAIL_SMTP_PASS;
+
+  _transporter = nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: user ? { user, pass } : undefined,
+    tls: { rejectUnauthorized: process.env.NODE_ENV === 'production' },
+    connectionTimeout: 10_000,
+    greetingTimeout: 5_000,
+    socketTimeout: 15_000,
+  }) as unknown as CachedTransporter;
+  return _transporter;
+}
+
+function from(): string {
+  return process.env.EMAIL_FROM ?? `noreply@${process.env.MAIL_HOST ?? 'preset-forge.com'}`;
+}
+
+function appUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.preset-forge.com';
+}
+
+export interface CriticalErrorPayload {
+  id: string;
+  fingerprint: string;
+  severity: string;
+  category: string;
+  message: string;
+  stack?: string;
+  route?: string;
+  method?: string;
+  count: number;
+}
+
+const STACK_MAX = 1500;
+
+export async function sendCriticalErrorEmail(p: CriticalErrorPayload): Promise<void> {
+  const to = process.env.ADMIN_EMAIL;
+  if (!to) {
+    // No recipient configured → silent no-op. The logger still records the
+    // error to the DB; we just can't alert anyone via mail in this deployment.
+    return;
+  }
+
+  const shortFp = p.fingerprint.slice(0, 8);
+  const stack = (p.stack ?? '').slice(0, STACK_MAX);
+  const occurrence = p.count === 1 ? 'first occurrence' : `${p.count}-th occurrence`;
+  const link = `${appUrl()}/admin?tab=errors&fingerprint=${p.fingerprint}`;
+
+  const subject = `[Preset Forge ${p.severity.toUpperCase()}] ${p.category}: ${p.message.slice(0, 80)}`;
+  const text = [
+    `Severity: ${p.severity}`,
+    `Category: ${p.category}`,
+    `Fingerprint: ${shortFp} (${occurrence})`,
+    p.route ? `Route: ${p.method ?? ''} ${p.route}`.trim() : null,
+    '',
+    'Message:',
+    p.message,
+    '',
+    stack ? 'Stack (truncated):' : null,
+    stack || null,
+    '',
+    `Admin link: ${link}`,
+  ]
+    .filter((line) => line !== null)
+    .join('\n');
+
+  await getTransporter().sendMail({ from: from(), to, subject, text });
+}

--- a/src/lib/errorLog.ts
+++ b/src/lib/errorLog.ts
@@ -1,30 +1,158 @@
+import { createHash } from 'node:crypto';
 import { prisma } from './prisma';
-import type { Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { sendCriticalErrorEmail } from './criticalErrorEmail';
 
-export function logError(opts: {
+export type ErrorSeverity = 'critical' | 'error' | 'warning' | 'info';
+export type ErrorCategory =
+  | 'api'
+  | 'client'
+  | 'auth'
+  | 'db'
+  | 's3'
+  | 'external'
+  | 'validation'
+  | 'rate_limit'
+  | 'legacy';
+
+export interface LogErrorOpts {
   message: string;
-  level?: 'error' | 'warn';
+  category?: ErrorCategory;
+  severity?: ErrorSeverity;
   stack?: string;
+  route?: string;
+  method?: string;
   url?: string;
   userId?: string;
+  ip?: string;
   metadata?: Record<string, unknown>;
-}): Promise<unknown> {
-  const level = opts.level ?? 'error';
+  /** Back-compat for the old `level: 'error' | 'warn'` signature. */
+  level?: 'error' | 'warn';
+}
 
-  if (level === 'error') {
-    console.error(`[ErrorLog] ${opts.message}`, opts.stack ?? '');
+const EMAIL_THROTTLE_MS = 60 * 60 * 1000; // 1h per fingerprint
+
+/** SHA-256(category|message), first 32 hex chars. Stable identity for grouping. */
+export function computeFingerprint(category: string, message: string): string {
+  return createHash('sha256').update(`${category}|${message}`).digest('hex').slice(0, 32);
+}
+
+/**
+ * Fire-and-forget error logger. Never throws — wraps DB + email failures so the
+ * caller path is never broken by the observability layer itself.
+ *
+ * Returns the affected row id (or null if logging itself failed) so callers can
+ * deep-link to /admin/errors/<id> from response payloads if they want to.
+ */
+export async function logError(opts: LogErrorOpts): Promise<string | null> {
+  // Translate the legacy `level` shorthand to the new severity + category model.
+  const severity: ErrorSeverity = opts.severity ?? (opts.level === 'warn' ? 'warning' : 'error');
+  const category: ErrorCategory = opts.category ?? 'api';
+  const fingerprint = computeFingerprint(category, opts.message);
+
+  // Mirror to console so existing log scrapers / docker logs still see something.
+  const logLine = `[ErrorLog:${severity}] ${category} ${opts.message}`;
+  if (severity === 'critical' || severity === 'error') {
+    console.error(logLine, opts.stack ?? '');
+  } else if (severity === 'warning') {
+    console.warn(logLine);
   } else {
-    console.warn(`[ErrorLog] ${opts.message}`);
+    console.info(logLine);
   }
 
-  return prisma.errorLog.create({
-    data: {
-      level,
-      message: opts.message,
-      stack: opts.stack ?? null,
-      url: opts.url ?? null,
-      userId: opts.userId ?? null,
-      metadata: opts.metadata as Prisma.InputJsonValue ?? null,
-    },
+  try {
+    const now = new Date();
+    const existing = await prisma.errorLog.findFirst({
+      where: { fingerprint, resolvedAt: null },
+      orderBy: { lastSeenAt: 'desc' },
+    });
+
+    let row;
+    if (existing) {
+      row = await prisma.errorLog.update({
+        where: { id: existing.id },
+        data: {
+          count: { increment: 1 },
+          lastSeenAt: now,
+          // Refresh contextual fields on every occurrence so the admin UI shows
+          // the *latest* invocation, not the original — that's what's needed
+          // when triaging "is this still happening / where".
+          stack: opts.stack ?? existing.stack,
+          route: opts.route ?? existing.route,
+          method: opts.method ?? existing.method,
+          url: opts.url ?? existing.url,
+          userId: opts.userId ?? existing.userId,
+          ip: opts.ip ?? existing.ip,
+          severity, // allow upgrading severity if the same fingerprint reoccurs harder
+        },
+      });
+    } else {
+      row = await prisma.errorLog.create({
+        data: {
+          fingerprint,
+          category,
+          severity,
+          message: opts.message,
+          stack: opts.stack ?? null,
+          route: opts.route ?? null,
+          method: opts.method ?? null,
+          url: opts.url ?? null,
+          userId: opts.userId ?? null,
+          ip: opts.ip ?? null,
+          metadata: (opts.metadata as Prisma.InputJsonValue) ?? Prisma.JsonNull,
+        },
+      });
+    }
+
+    if (severity === 'critical') {
+      await maybeSendCriticalEmail(row.id, fingerprint, row.lastEmailedAt, {
+        severity,
+        category,
+        message: opts.message,
+        stack: opts.stack,
+        route: opts.route,
+        method: opts.method,
+        count: row.count,
+      });
+    }
+
+    return row.id;
+  } catch (err) {
+    console.error('[ErrorLog] failed to persist error', err);
+    return null;
+  }
+}
+
+async function maybeSendCriticalEmail(
+  id: string,
+  fingerprint: string,
+  lastEmailedAt: Date | null,
+  body: {
+    severity: ErrorSeverity;
+    category: ErrorCategory;
+    message: string;
+    stack?: string;
+    route?: string;
+    method?: string;
+    count: number;
+  },
+): Promise<void> {
+  const now = Date.now();
+  if (lastEmailedAt && now - lastEmailedAt.getTime() < EMAIL_THROTTLE_MS) return;
+
+  // Claim the throttle slot *before* sending so two concurrent critical errors
+  // can't both pass the check and double-send. If the send itself fails we
+  // still keep lastEmailedAt set — the next occurrence within the hour just
+  // won't retry, which is the correct tradeoff (alert fatigue > silent
+  // duplicate spam).
+  await prisma.errorLog.update({
+    where: { id },
+    data: { lastEmailedAt: new Date(now) },
   });
+
+  try {
+    await sendCriticalErrorEmail({ id, fingerprint, ...body });
+  } catch (err) {
+    console.error('[ErrorLog] critical-email send failed', err);
+  }
 }

--- a/src/lib/validators.admin.ts
+++ b/src/lib/validators.admin.ts
@@ -41,9 +41,19 @@ export const adminPresetsQuerySchema = z.object({
 
 export const adminErrorsQuerySchema = z.object({
   q: z.string().max(100).optional(),
-  level: z.enum(['error', 'warn']).optional(),
+  severity: z.enum(['critical', 'error', 'warning', 'info']).optional(),
+  category: z.enum(['api', 'client', 'auth', 'db', 's3', 'external', 'validation', 'rate_limit', 'legacy']).optional(),
+  resolved: z.enum(['true', 'false']).optional(),
   page: z.string().optional().transform((v) => Math.max(1, parseInt(v ?? '1', 10) || 1)),
   limit: z.string().optional().transform((v) => Math.min(50, Math.max(1, parseInt(v ?? '20', 10) || 20))),
+});
+
+export const adminErrorsPatchSchema = z.object({
+  fingerprint: z.string().min(8).max(64).optional(),
+  ids: z.string().min(1).array().max(100).optional(),
+  resolved: z.boolean(),
+}).refine((v) => v.fingerprint || (v.ids && v.ids.length > 0), {
+  message: 'Either fingerprint or ids[] is required',
 });
 
 export const adminActionsQuerySchema = z.object({

--- a/tests/unit/errorLog.test.ts
+++ b/tests/unit/errorLog.test.ts
@@ -1,49 +1,165 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@/lib/prisma', () => ({
-  prisma: {
+// vi.hoisted() escapes the TDZ trap: vi.mock() factories are hoisted above
+// imports, but consts declared at module-top are not. Using hoisted() puts the
+// mock variables in the same hoisted scope as the mock factory.
+const { prismaMock, emailMock } = vi.hoisted(() => ({
+  prismaMock: {
     errorLog: {
-      create: vi.fn().mockResolvedValue({ id: 'test-id' }),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
   },
+  emailMock: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { logError } from '@/lib/errorLog';
-import { prisma } from '@/lib/prisma';
+vi.mock('@/lib/prisma', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/criticalErrorEmail', () => ({ sendCriticalErrorEmail: emailMock }));
 
-describe('logError', () => {
-  it('creates error log entry with defaults', async () => {
-    await logError({ message: 'Test error' });
-    expect(prisma.errorLog.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        level: 'error',
-        message: 'Test error',
-        stack: null,
-        url: null,
-        userId: null,
-        metadata: null,
-      }),
-    });
+import { logError, computeFingerprint } from '@/lib/errorLog';
+
+beforeEach(() => {
+  prismaMock.errorLog.findFirst.mockReset();
+  prismaMock.errorLog.create.mockReset();
+  prismaMock.errorLog.update.mockReset();
+  emailMock.mockReset();
+  emailMock.mockResolvedValue(undefined);
+});
+
+describe('computeFingerprint', () => {
+  it('is stable for the same category+message', () => {
+    const a = computeFingerprint('api', 'Boom');
+    const b = computeFingerprint('api', 'Boom');
+    expect(a).toBe(b);
+    expect(a).toHaveLength(32);
   });
 
-  it('passes all fields when provided', async () => {
-    await logError({
-      message: 'S3 timeout',
-      level: 'warn',
-      stack: 'Error: timeout\n  at upload',
-      url: '/api/presets',
-      userId: 'user123',
-      metadata: { fileSize: 1224 },
+  it('differs when category changes', () => {
+    expect(computeFingerprint('api', 'Boom')).not.toBe(computeFingerprint('client', 'Boom'));
+  });
+
+  it('differs when message changes', () => {
+    expect(computeFingerprint('api', 'Boom')).not.toBe(computeFingerprint('api', 'Boom2'));
+  });
+});
+
+describe('logError - create vs update', () => {
+  it('creates a new row when no existing fingerprint matches', async () => {
+    prismaMock.errorLog.findFirst.mockResolvedValue(null);
+    prismaMock.errorLog.create.mockResolvedValue({ id: 'new-id', count: 1, lastEmailedAt: null });
+
+    await logError({ message: 'Fresh error', category: 'api' });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.errorLog.update).not.toHaveBeenCalled();
+    const created = prismaMock.errorLog.create.mock.calls[0][0].data;
+    expect(created.fingerprint).toBe(computeFingerprint('api', 'Fresh error'));
+    expect(created.severity).toBe('error');
+    expect(created.category).toBe('api');
+  });
+
+  it('increments count on existing unresolved row instead of inserting', async () => {
+    prismaMock.errorLog.findFirst.mockResolvedValue({
+      id: 'existing-id',
+      count: 5,
+      lastEmailedAt: null,
+      stack: 'old stack',
+      route: '/old',
+      method: 'GET',
+      url: null,
+      userId: null,
+      ip: null,
     });
-    expect(prisma.errorLog.create).toHaveBeenCalledWith({
-      data: {
-        level: 'warn',
-        message: 'S3 timeout',
-        stack: 'Error: timeout\n  at upload',
-        url: '/api/presets',
-        userId: 'user123',
-        metadata: { fileSize: 1224 },
-      },
+    prismaMock.errorLog.update.mockResolvedValue({ id: 'existing-id', count: 6, lastEmailedAt: null });
+
+    await logError({ message: 'Recurring', category: 'api', stack: 'new stack', route: '/new' });
+
+    expect(prismaMock.errorLog.create).not.toHaveBeenCalled();
+    expect(prismaMock.errorLog.update).toHaveBeenCalledTimes(1);
+    const updateArgs = prismaMock.errorLog.update.mock.calls[0][0];
+    expect(updateArgs.where.id).toBe('existing-id');
+    expect(updateArgs.data.count).toEqual({ increment: 1 });
+    // contextual fields should be refreshed to the latest occurrence
+    expect(updateArgs.data.stack).toBe('new stack');
+    expect(updateArgs.data.route).toBe('/new');
+  });
+
+  it('maps legacy level=warn → severity=warning', async () => {
+    prismaMock.errorLog.findFirst.mockResolvedValue(null);
+    prismaMock.errorLog.create.mockResolvedValue({ id: 'w', count: 1, lastEmailedAt: null });
+
+    await logError({ message: 'Soft fail', level: 'warn' });
+
+    expect(prismaMock.errorLog.create.mock.calls[0][0].data.severity).toBe('warning');
+  });
+
+  it('returns null without throwing when the DB call rejects', async () => {
+    prismaMock.errorLog.findFirst.mockRejectedValue(new Error('db down'));
+
+    const result = await logError({ message: 'never persists' });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('logError - critical email trigger', () => {
+  it('sends a mail on first critical occurrence and claims the throttle slot', async () => {
+    prismaMock.errorLog.findFirst.mockResolvedValue(null);
+    prismaMock.errorLog.create.mockResolvedValue({ id: 'crit-id', count: 1, lastEmailedAt: null });
+    // second update call is the lastEmailedAt claim
+    prismaMock.errorLog.update.mockResolvedValue({ id: 'crit-id' });
+
+    await logError({ message: 'CRITICAL', category: 'api', severity: 'critical' });
+
+    expect(emailMock).toHaveBeenCalledTimes(1);
+    // lastEmailedAt claim happens BEFORE the send so concurrent triggers don't double-send
+    expect(prismaMock.errorLog.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'crit-id' },
+        data: expect.objectContaining({ lastEmailedAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it('suppresses mail when lastEmailedAt is within the 1h throttle window', async () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+    prismaMock.errorLog.findFirst.mockResolvedValue({
+      id: 'crit-id',
+      count: 10,
+      lastEmailedAt: fiveMinAgo,
+      stack: null, route: null, method: null, url: null, userId: null, ip: null,
     });
+    prismaMock.errorLog.update.mockResolvedValue({ id: 'crit-id', count: 11, lastEmailedAt: fiveMinAgo });
+
+    await logError({ message: 'CRITICAL', category: 'api', severity: 'critical' });
+
+    expect(emailMock).not.toHaveBeenCalled();
+  });
+
+  it('resends mail when the throttle window has elapsed', async () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    prismaMock.errorLog.findFirst.mockResolvedValue({
+      id: 'crit-id',
+      count: 50,
+      lastEmailedAt: twoHoursAgo,
+      stack: null, route: null, method: null, url: null, userId: null, ip: null,
+    });
+    prismaMock.errorLog.update.mockResolvedValue({ id: 'crit-id', count: 51, lastEmailedAt: twoHoursAgo });
+
+    await logError({ message: 'CRITICAL', category: 'api', severity: 'critical' });
+
+    expect(emailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never sends mail for non-critical severities', async () => {
+    prismaMock.errorLog.findFirst.mockResolvedValue(null);
+    prismaMock.errorLog.create.mockResolvedValue({ id: 'e', count: 1, lastEmailedAt: null });
+
+    await logError({ message: 'normal', severity: 'error' });
+    await logError({ message: 'normal', severity: 'warning' });
+    await logError({ message: 'normal', severity: 'info' });
+
+    expect(emailMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/validators.admin.test.ts
+++ b/tests/unit/validators.admin.test.ts
@@ -70,10 +70,15 @@ describe('adminPresetsQuerySchema', () => {
 });
 
 describe('adminErrorsQuerySchema', () => {
-  it('accepts level filter', () => {
-    expect(adminErrorsQuerySchema.safeParse({ level: 'error' }).success).toBe(true);
+  it('accepts severity filter', () => {
+    expect(adminErrorsQuerySchema.safeParse({ severity: 'critical' }).success).toBe(true);
   });
-  it('rejects invalid level', () => {
-    expect(adminErrorsQuerySchema.safeParse({ level: 'debug' }).success).toBe(false);
+  it('rejects unknown severity', () => {
+    expect(adminErrorsQuerySchema.safeParse({ severity: 'debug' }).success).toBe(false);
+  });
+  it('accepts category + resolved combination', () => {
+    expect(
+      adminErrorsQuerySchema.safeParse({ category: 'client', resolved: 'true' }).success,
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Implements Issue #70: ErrorLog v2 with fingerprint grouping, critical-error email alerts, and client-side error reporting.

## What changes

**Schema (Prisma migration with backfill):**
- `ErrorLog.level` → `severity` (`critical` | `error` | `warning` | `info`)
- New: `fingerprint`, `category`, `route`, `method`, `ip`, `count`, `firstSeenAt`, `lastSeenAt`, `resolvedAt`, `lastEmailedAt`
- Existing rows backfilled as `category='legacy'`, `severity` mapped from `level`, fingerprint via `md5('legacy|'||message)`

**Logger (`src/lib/errorLog.ts`):**
- 1000 identical crashes → 1 row with `count=1000`
- `severity='critical'` → email to `ADMIN_EMAIL`, throttled 1/hour per fingerprint
- Fire-and-forget: DB/mail failures never break callers
- 13 existing call-sites work unchanged via `level` back-compat shim

**Admin:**
- `/api/admin/errors`: severity/category/resolved filters + `unresolvedCounts` for sidebar
- `/api/admin/errors PATCH`: bulk-resolve by fingerprint (groups all matching rows)
- UI: severity-colored badge, category chip, ×N count pill, Resolve/Reopen button per group, resolved rows dimmed

**Client errors:**
- `src/app/[locale]/error.tsx` posts uncaught render errors to new `POST /api/errors/client` (rate-limited 30/min/IP, anonymous allowed, session user attached if present)

**i18n:** all 7 locales gain `admin.actions.resolve/unresolve` and a new `error.{title,body,retry}` block.

## Acceptance criteria (from #70)

- [x] Provoked critical crash → exactly **one** email within the first hour (test: `'sends a mail on first critical occurrence and claims the throttle slot'`)
- [x] Same crash 100× → counter increment, no 100 rows (test: `'increments count on existing unresolved row instead of inserting'`)
- [x] Fingerprint-grouped admin list with severity/category/resolved filters
- [x] Sidebar badge data exposed (`unresolvedCounts` in GET response — wiring badge into sidebar component itself is a follow-up if you want it visible)
- [x] Legacy rows still visible after migration (backfilled `category=legacy`)
- [x] Vitest tests for fingerprint stability and mail-throttling (11 new tests)

## Deployment notes

- Migration must run before deploy → `scripts/deploy-update.sh` does `prisma migrate deploy` automatically
- `ADMIN_EMAIL` env var needs to be set on prod for mail trigger to actually send. Absent it, errors still log to DB but no alerts go out.
- No prod deploy in this session — wait for review.

## Test plan
- [x] `npm run ci` passes (731 tests, lint, typecheck, build)
- [ ] Local smoke: provoke an `await logError({ severity: 'critical', ... })` and verify mail lands at ADMIN_EMAIL (requires SMTP to be reachable)
- [ ] Local smoke: throw inside a `[locale]` page → error.tsx renders → /admin/errors shows it as `category=client`
- [ ] After deploy: provoke a known critical path → first occurrence emails, second within 1h does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)