### PR TITLE
fix(email): add EMAIL_SMTP_TLS_SERVERNAME support for SNI override

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -40,6 +40,11 @@ function getTransporter(): CachedTransporter {
   const port = Number(process.env.MAIL_PORT ?? process.env.EMAIL_SMTP_PORT ?? 1025);
   const user = process.env.MAIL_USERNAME ?? process.env.EMAIL_SMTP_USER;
   const pass = process.env.MAIL_PASSWORD ?? process.env.EMAIL_SMTP_PASS;
+  // When the SMTP host resolves to the right server but the TLS cert is issued
+  // for a different hostname (e.g. preset-forge.com → 82.165.40.140, cert for
+  // mail.mr-development.de), set EMAIL_SMTP_TLS_SERVERNAME to the cert hostname
+  // so nodemailer sends the correct SNI and validation succeeds.
+  const tlsServername = process.env.EMAIL_SMTP_TLS_SERVERNAME;
 
   // Cast the pool-transporter to the non-pool Transporter shape we cache.
   // The two share the sendMail surface we use; the pool variant adds a
@@ -49,7 +54,10 @@ function getTransporter(): CachedTransporter {
     port,
     secure: port === 465,
     auth: user ? { user, pass } : undefined,
-    tls: { rejectUnauthorized: process.env.NODE_ENV === 'production' },
+    tls: {
+      rejectUnauthorized: process.env.NODE_ENV === 'production',
+      ...(tlsServername ? { servername: tlsServername } : {}),
+    },
     pool: true,
     maxConnections: 3,
     connectionTimeout: 10_000,


### PR DESCRIPTION
## Problem

`preset-forge.com` resolves to the same server as `mail.mr-development.de` (82.165.40.140), but the Let's Encrypt TLS cert is only issued for `mail.mr-development.de`. When `EMAIL_SMTP_HOST=preset-forge.com`, nodemailer uses `preset-forge.com` as the TLS SNI servername — the mailserver presents its `mail.mr-development.de` cert — validation fails with:

> Hostname/IP does not match certificate's altnames: Host: preset-forge.com is not in the cert's altnames: DNS:mail.mr-development.de

This has been logged as repeated errors since March 2026.

## Solution

Adds optional `EMAIL_SMTP_TLS_SERVERNAME` env var. When set, it is passed as `tls.servername` to nodemailer, overriding the SNI hostname used for cert validation — independently of the `host` used for the TCP connection.

**Prod `.env.prod` now set to:**
```
EMAIL_SMTP_HOST=preset-forge.com
EMAIL_SMTP_TLS_SERVERNAME=mail.mr-development.de
```

This connects to the correct server via `preset-forge.com` DNS, while validating TLS against `mail.mr-development.de` (the cert's SAN). Other systems using the mailserver are unaffected.

## Test plan

- [ ] Deploy to prod and register a new user → verify email arrives
- [ ] Check `ErrorLog` table — no new `altnames` errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)