### PR TITLE
docs(captures): capture catalog, GUI capture tool & guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ Preset Forge is the **only GP-200 editor that runs on Linux**. Tested on Linux M
 
 For USB MIDI on Linux: install Chrome or Chromium, connect the GP-200 via USB, and grant MIDI permission when the browser asks.
 
+## Reporting a USB problem (send a capture)
+
+Hit a bug with live USB editing — an effect won't switch, a preset won't save, an
+IR/NAM won't load? You can record the USB-MIDI traffic between your PC and the
+GP-200 and send it to us. That capture lets us reproduce and fix the issue.
+
+A small GUI tool makes this easy — no command line required:
+
+```bash
+python scripts/gp200-capture-gui.py        # Windows: run as Administrator
+```
+
+Connect the GP-200, pick the USB interface, click **Start**, reproduce the
+problem, click **Stop**, then attach the resulting `.pcap` file to a
+[GitHub issue](https://github.com/phash/gp200editor/issues).
+
+Full setup (Wireshark + USBPcap + Python/Tkinter), step-by-step instructions and
+troubleshooting: **[docs/capture-tool.md](docs/capture-tool.md)**.
+
 ## Features
 
 - **Preset Editor** — `.prst` files (1224 bytes, 11 slots, 305 effects, 15 parameters per effect). Pedalboard view with patch cables

--- a/docs/capture-catalog.md
+++ b/docs/capture-catalog.md
@@ -1,0 +1,210 @@
+# GP-200 Capture Catalog
+
+Auto-generierter Katalog aller lokalen USB-MIDI Captures. Erzeugt mit `python scripts/build-capture-catalog.py` (nutzt `analyze-sysex.py`).
+
+> ⚠️ Die `.pcap`-Rohdaten sind **nicht** im Git-Repo (`scripts/*.pcap` untracked, `caps/` in `.gitignore`). Dieser Katalog ist die durchsuchbare Übersicht; die Binärdaten liegen nur lokal / im Backup.
+
+- **Captures:** 130
+- **Gesamtgröße:** 619.7 MB
+- **SysEx-Nachrichten gesamt:** 32913
+
+Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
+
+## Benannte Captures (`caps/`)
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-effect-change.pcap` | 18 KB | 24 | IR/NAM multi-chunk upload (sub=0x1C) ×23; CMD 12 sub 0C ×1 |
+| `gp200-ir-load-user.pcap` | 18 KB | 24 | IR/NAM multi-chunk upload (sub=0x1C) ×23; CMD 12 sub 0C ×1 |
+| `gp200-ir-load-userIR3.pcap` | 19 KB | 29 | Toggle [CAB+]; IR/NAM multi-chunk upload (sub=0x1C) ×23; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×2; CMD 12 sub 08 ×1 |
+| `gp200-ir-load.pcap` | 36 KB | 60 | Toggle [CAB+,PRE+,WAH-]; IR/NAM multi-chunk upload (sub=0x1C) ×46; CMD 12 sub 0C ×4; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 08 ×2 |
+| `gp200-nam-load.pcap` | 34 KB | 51 | Toggle [AMP+]; IR/NAM multi-chunk upload (sub=0x1C) ×45; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×2; CMD 12 sub 08 ×1 |
+| `gp200-nam-load2.pcap` | 34 KB | 50 | IR/NAM multi-chunk upload (sub=0x1C) ×45; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×2; CMD 12 sub 08 ×1 |
+
+## Zeitstempel-Captures (`scripts/`)
+
+### 2026-03-18
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260318-231056.pcap` | 1.9 MB | 20 | Preset-Write → Slot [9] 'American Idiot'; Preset-Change (1×, #[10]); Toggle [EQ+,NR+,PRE-,WAH-]; CMD 12 sub 18 ×7 |
+| `gp200-capture-20260318-232435.pcap` | 2.0 MB | 9 | Preset-Change (4×, #[7, 9, 10, 11]); Toggle [NR+,PRE-,VOL-] |
+| `gp200-capture-20260318-232621.pcap` | 1.5 MB | 10 | Preset-Change (3×, #[9, 10, 11]); Toggle [NR+,PRE-]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260318-235014.pcap` | 1.4 MB | 40 | Preset-Change (18×, #[0, 1, 2, 3, 4, 5, 6]) |
+| `gp200-capture-20260318-235247.pcap` | 595 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260318-235705.pcap` | 2.7 MB | 69 | IR/NAM multi-chunk upload (sub=0x1C) ×69 |
+| `gp200-capture-20260318-235943.pcap` | 545 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
+
+### 2026-03-19
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260319-003621.pcap` | 486 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-003827.pcap` | 1.1 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-010828.pcap` | 3.3 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-010955.pcap` | 2.7 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-011106.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-011157.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-011229.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-011529.pcap` | 1.1 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-011832.pcap` | 3.6 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-012329.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-012527.pcap` | 529 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-072019.pcap` | 0 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-072053.pcap` | 227 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-072121.pcap` | 29 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-072144.pcap` | 114 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-072206.pcap` | 1.1 MB | 2173 | Preset-Read/State-Dump (257 Presets); CMD 11 sub 1C ×34; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260319-100435.pcap` | 2 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-100523.pcap` | 1 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-100548.pcap` | 9 KB | 14 | Preset-Change (1×, #[0]); Toggle [BOOST-,CAB+,DLY+,MOD+,PRE-,WAH-]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260319-101538.pcap` | 15 KB | 43 | Preset-Change (1×, #[0]); Toggle [AMP+,CAB+,DLY+,PRE-,VOL+,VOL-,WAH-]; CMD 12 sub 18 ×23; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 0C ×2; CMD 12 sub 08 ×2; CMD 12 sub 20 ×1 |
+| `gp200-capture-20260319-101714.pcap` | 49 KB | 213 | Toggle [BOOST+,WAH-]; CMD 12 sub 18 ×203; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 20 ×2; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260319-102448.pcap` | 21.9 MB | 335 | CMD 12 sub 18 ×334 |
+| `gp200-capture-20260319-102857.pcap` | 21.3 MB | 870 | CMD 12 sub 18 ×866; CMD 12 sub 0C ×2; param/effect-change or controller assignment (sub=0x14, 54B raw) ×1; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260319-103852.pcap` | 44.3 MB | 453 | Toggle [EQ-,PRE-,WAH-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×8 |
+| `gp200-capture-20260319-104211.pcap` | 162.0 MB | 139 | Toggle [PRE+,PRE-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×64; CMD 12 sub 18 ×3 |
+| `gp200-capture-20260319-104836.pcap` | 21.3 MB | 7 | Toggle [BOOST-]; CMD 12 sub 20 ×1; CMD 12 sub 18 ×1; CMD 12 sub 38 ×1 |
+| `gp200-capture-20260319-105520.pcap` | 21.0 MB | 213 | fx_state_resp×213 |
+| `gp200-capture-20260319-105713.pcap` | 27 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
+| `gp200-capture-20260319-114423.pcap` | 7 KB | 6 | Toggle [PRE+]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260319-114632.pcap` | 1.2 MB | 2211 | Preset-Read/State-Dump (259 Presets); CMD 11 sub 1C ×60; IR/NAM multi-chunk upload (sub=0x1C) ×54; state-dump chunk (sub=0x4E) ×10; CMD 11 sub 04 ×4; CMD 11 sub 12 ×2; CMD 11 sub 0A ×2; CMD 12 sub 0A ×2 |
+| `gp200-capture-20260319-114725.pcap` | 34.4 MB | 2218 | Preset-Write → Slot [0] 'Pretender 3'; Preset-Read/State-Dump (258 Presets); Preset-Change (1×, #[0]); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,BOOST,CAB,DLY,EQ,MOD,NR,PRE,PRE+,RVB,VOL,WAH,WAH-]; CMD 11 sub 1C ×60; IR/NAM multi-chunk upload (sub=0x1C) ×54; state-dump chunk (sub=0x4E) ×10; CMD 12 sub 18 ×6; CMD 11 sub 04 ×4; CMD 11 sub 12 ×2; CMD 11 sub 0A ×2; CMD 12 sub 0A ×2; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260319-221628.pcap` | 82.6 MB | 6 | Preset-Change (2×, #[0, 4]); Toggle [PRE-,VOL+] |
+| `gp200-capture-20260319-221746.pcap` | 250 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-221950.pcap` | 88.8 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260319-222343.pcap` | 12 KB | 33 | Preset-Change (8×, #[0, 1, 2, 3, 4, 5, 6, 7]); Toggle [?0D+,CAB+,PRE-,VOL+,WAH+] |
+
+### 2026-03-20
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260320-143029.pcap` | 13 KB | 14 | Preset-Change (1×, #[1]); Toggle [BOOST-,NR+,PRE-]; CMD 12 sub 20 ×1; CMD 12 sub 38 ×1; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260320-151140.pcap` | 1.1 MB | 2175 | Preset-Read/State-Dump (257 Presets); CMD 11 sub 1C ×32; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260320-152209.pcap` | 6 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260320-152215.pcap` | 48 KB | 77 | Preset-Read/State-Dump (9 Presets); Preset-Change (2×, #[2]); Toggle [AMP,BOOST,NR+,PRE,PRE-,VOL+,WAH] |
+
+### 2026-03-23
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260323-121456.pcap` | 6.9 MB | 2 | Toggle [EQ+,NR+] |
+| `gp200-capture-20260323-121520.pcap` | 6.9 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260323-121559.pcap` | 11 KB | 23 | CMD 12 sub 20 ×11; param/effect-change or controller assignment (sub=0x14, 54B raw) ×11 |
+| `gp200-capture-20260323-121732.pcap` | 9 KB | 11 | Preset-Change (4×, #[1, 15]); Toggle [NR+,PRE-]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-121825.pcap` | 10 KB | 17 | Preset-Change (4×, #[0, 1]); Toggle [NR+,PRE-,WAH-]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-122109.pcap` | 15 KB | 51 | Preset-Change (5×, #[0]); Toggle [BOOST+,CAB+,NR+,PRE-,WAH-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×7; CMD 12 sub 0C ×7; CMD 12 sub 08 ×7; CMD 12 sub 18 ×5 |
+| `gp200-capture-20260323-122305.pcap` | 31 KB | 149 | Preset-Change (1×, #[0]); Toggle [EQ-,NR+,PRE-,WAH-]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-122704.pcap` | 22.3 MB | 34 | param/effect-change or controller assignment (sub=0x14, 54B raw) ×33 |
+| `gp200-capture-20260323-122940.pcap` | 10.2 MB | 2 | param/effect-change or controller assignment (sub=0x14, 54B raw) ×1 |
+| `gp200-capture-20260323-124534.pcap` | 71 KB | 124 | Preset-Read/State-Dump (14 Presets); Toggle [AMP,BOOST,BOOST+,CAB,NR,NR+,PRE,PRE-,VOL+,WAH] |
+| `gp200-capture-20260323-124718.pcap` | 7.3 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260323-124730.pcap` | 10 KB | 24 | Toggle [NR+,PRE-,VOL+] |
+| `gp200-capture-20260323-130830.pcap` | 30 KB | 45 | Preset-Read/State-Dump (5 Presets); Toggle [BOOST+,BOOST-,NR+,PRE] |
+| `gp200-capture-20260323-131350.pcap` | 7 KB | 4 | Toggle [BOOST+,NR+,PRE-,WAH-] |
+| `gp200-capture-20260323-131507.pcap` | 7 KB | 6 | Toggle [BOOST+,NR+,PRE-,WAH-]; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-131738.pcap` | 16 KB | 22 | Preset-Read/State-Dump (2 Presets); Toggle [NR+,PRE,PRE-,WAH-]; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-134033.pcap` | 8 KB | 10 | CMD 12 sub 0C ×5; CMD 12 sub 08 ×4 |
+| `gp200-capture-20260323-134538.pcap` | 45 KB | 12 | Toggle [MOD+]; CMD 12 sub 0C ×6; CMD 12 sub 08 ×5 |
+| `gp200-capture-20260323-134828.pcap` | 45 KB | 10 | CMD 12 sub 0C ×4; CMD 12 sub 08 ×4; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2 |
+| `gp200-capture-20260323-140802.pcap` | 76 KB | 415 | Toggle [EQ-,NR+,PRE-,WAH-] |
+| `gp200-capture-20260323-141104.pcap` | 19 KB | 75 | Toggle [PRE-,WAH-] |
+| `gp200-capture-20260323-141239.pcap` | 9 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260323-141331.pcap` | 145 KB | 651 | Preset-Read/State-Dump (8 Presets); Toggle [AMP,BOOST,EQ-,PRE,PRE-,WAH,WAH-]; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 1C ×4; IR/NAM multi-chunk upload (sub=0x1C) ×3; CMD 11 sub 04 ×2; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260323-142122.pcap` | 8 KB | 14 | fx_state_resp×14 |
+| `gp200-capture-20260323-142750.pcap` | 41 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
+| `gp200-capture-20260323-143107.pcap` | 99 KB | 96 | Toggle [AMP+]; IR/NAM multi-chunk upload (sub=0x1C) ×90; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-143826.pcap` | 63 KB | 45 | IR/NAM multi-chunk upload (sub=0x1C) ×45 |
+| `gp200-capture-20260323-172312.pcap` | 11 KB | 22 | CMD 12 sub 0C ×9; param/effect-change or controller assignment (sub=0x14, 54B raw) ×6; CMD 12 sub 08 ×6 |
+| `gp200-capture-20260323-172452.pcap` | 116 KB | 222 | Preset-Read/State-Dump (22 Presets); Preset-Change (4×, #[0]); Toggle [AMP,BOOST,CAB-,PRE,WAH,WAH-]; CMD 12 sub 08 ×12; param/effect-change or controller assignment (sub=0x14, 54B raw) ×9; CMD 12 sub 0C ×9 |
+| `gp200-capture-20260323-172614.pcap` | 10 KB | 14 | CMD 12 sub 0C ×6; param/effect-change or controller assignment (sub=0x14, 54B raw) ×4; CMD 12 sub 08 ×4 |
+| `gp200-capture-20260323-172728.pcap` | 10 KB | 18 | param/effect-change or controller assignment (sub=0x14, 54B raw) ×6; CMD 12 sub 0C ×6; CMD 12 sub 08 ×6 |
+| `gp200-capture-20260323-174918.pcap` | 9 KB | 9 | Toggle [AMP+]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 0C ×3; CMD 12 sub 08 ×2 |
+| `gp200-capture-20260323-175101.pcap` | 8.5 MB | 2267 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0B+,?0C,?0C+,?0D,?0E,?0F,AMP,AMP+,BOOST,CAB,DLY,EQ,MOD,NR,PRE,PRE+,RVB,VOL,VOL+,WAH,WAH-]; CMD 11 sub 04 ×45; CMD 11 sub 1C ×30; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 12 ×23; CMD 12 sub 12 ×22; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1; CMD 12 sub 04 ×1 |
+| `gp200-capture-20260323-180104.pcap` | 2.3 MB | 54 | Toggle [AMP+]; IR/NAM multi-chunk upload (sub=0x1C) ×45; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 0C ×2; CMD 12 sub 08 ×2 |
+| `gp200-capture-20260323-182011.pcap` | 61 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260323-182027.pcap` | 317 KB | 4 | CMD 11 sub 04 ×2; CMD 11 sub 12 ×1; CMD 12 sub 12 ×1 |
+| `gp200-capture-20260323-183245.pcap` | 30 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
+| `gp200-capture-20260323-200348.pcap` | 7 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260323-200453.pcap` | 7 KB | 3 | Preset-Change (1×, #[0]); Toggle [PRE-,RVB+] |
+| `gp200-capture-20260323-200517.pcap` | 22 KB | 80 | Toggle [PRE-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×25; CMD 12 sub 18 ×9; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-201458.pcap` | 33 KB | 170 | fx_state_resp×170 |
+| `gp200-capture-20260323-203246.pcap` | 43 KB | 30 | Preset-Read/State-Dump (2 Presets); Preset-Change (2×, #[0, 1]); Toggle [PRE,PRE-,RVB+,WAH,WAH-]; CMD 12 sub 18 ×2; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-203344.pcap` | 24 KB | 26 | Preset-Read/State-Dump (2 Presets); Preset-Change (2×, #[0, 2]); Toggle [BOOST,PRE,PRE-,RVB+,WAH-]; CMD 12 sub 18 ×1; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-203439.pcap` | 42 KB | 36 | Toggle [PRE-,WAH-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×18 |
+| `gp200-capture-20260323-203547.pcap` | 20 KB | 8 | Toggle [PRE-]; CMD 12 sub 18 ×2; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-203642.pcap` | 63 KB | 113 | Preset-Read/State-Dump (12 Presets); Preset-Change (3×, #[0, 1]); Toggle [AMP,BOOST,PRE,PRE-,RVB+,WAH,WAH-]; CMD 12 sub 08 ×3; CMD 12 sub 18 ×2 |
+| `gp200-capture-20260323-203730.pcap` | 27 KB | 31 | Preset-Change (2×, #[0, 1]); Toggle [PRE-,RVB+,WAH-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×9; CMD 12 sub 18 ×1; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-203838.pcap` | 33 KB | 44 | Preset-Change (1×, #[0]); Toggle [PRE-,RVB+,WAH-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×20 |
+| `gp200-capture-20260323-204011.pcap` | 23 KB | 87 | Toggle [PRE-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×42; CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-204352.pcap` | 9 KB | 12 | Toggle [PRE-]; CMD 12 sub 18 ×3 |
+| `gp200-capture-20260323-210733.pcap` | 7 KB | 1 | CMD 12 sub 18 ×1 |
+| `gp200-capture-20260323-210958.pcap` | 62 KB | 107 | Preset-Read/State-Dump (11 Presets); Preset-Change (1×, #[1]); Toggle [AMP,BOOST,EQ+,PRE,PRE-,WAH,WAH-]; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×2; CMD 11 sub 1C ×2; CMD 12 sub 18 ×2; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1; IR/NAM multi-chunk upload (sub=0x1C) ×1 |
+| `gp200-capture-20260323-211407.pcap` | 1.2 MB | 2287 | Preset-Read/State-Dump (266 Presets); CMD 11 sub 1C ×64; IR/NAM multi-chunk upload (sub=0x1C) ×39; CMD 12 sub 18 ×21; CMD 11 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×4; CMD 11 sub 0A ×2; CMD 12 sub 0A ×2; CMD 11 sub 12 ×1 |
+| `gp200-capture-20260323-211645.pcap` | 9 KB | 10 | Toggle [PRE-]; CMD 12 sub 18 ×4; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260323-212146.pcap` | 7 KB | 3 | Toggle [PRE-]; CMD 12 sub 18 ×1; CMD 12 sub 08 ×1 |
+
+### 2026-03-24
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260324-084047.pcap` | 1.6 MB | 2169 | Preset-Read/State-Dump (257 Presets); CMD 11 sub 1C ×30; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×21; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260324-084156.pcap` | 1.1 MB | 2172 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,BOOST,CAB,DLY,EQ,EQ+,MOD,NR,PRE,PRE-,RVB,VOL,WAH,WAH-]; CMD 11 sub 1C ×31; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260324-085205.pcap` | 197 KB | 1073 | Toggle [?0B+,?0C+,?0D+,?0E+,?0F+,AMP+,BOOST+,CAB+,DLY+,EQ+,MOD+,NR+,PRE+,PRE-,RVB+,VOL+,WAH+,WAH-] |
+| `gp200-capture-20260324-142215.pcap` | 1.5 MB | 1328 | Preset-Read/State-Dump (166 Presets) |
+| `gp200-capture-20260324-142234.pcap` | 6.7 MB | 2179 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,BOOST,CAB,DLY,EQ,EQ+,EQ-,MOD,NR,PRE,RVB,RVB+,VOL,WAH,WAH-]; CMD 11 sub 1C ×31; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×4; CMD 11 sub 12 ×2; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260324-142321.pcap` | 1.2 MB | 2253 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,AMP+,BOOST,CAB,CAB+,CAB-,DLY,EQ,MOD,NR,PRE,RVB,VOL,WAH,WAH-]; IR/NAM multi-chunk upload (sub=0x1C) ×98; CMD 11 sub 1C ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; param/effect-change or controller assignment (sub=0x14, 54B raw) ×4; CMD 11 sub 04 ×3; CMD 12 sub 0C ×2; CMD 12 sub 08 ×2; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
+| `gp200-capture-20260324-153246.pcap` | 4 KB | 0 | leer / kein GP-200 SysEx |
+
+### 2026-04-12
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260412-143324.pcap` | 1.2 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-143406.pcap` | 990 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-143450.pcap` | 680 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-143509.pcap` | 70 KB | 329 | CMD 12 sub 18 ×329 |
+| `gp200-capture-20260412-143526.pcap` | 305 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-143550.pcap` | 1.6 MB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-143552.pcap` | 223 KB | 1093 | Toggle [CAB+,CAB-]; CMD 12 sub 18 ×1086; param/effect-change or controller assignment (sub=0x14, 54B raw) ×1; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1 |
+| `gp200-capture-20260412-143744.pcap` | 665 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-143745.pcap` | 12 KB | 11 | Preset-Write → Slot [9] 'American Idiot'; Preset-Change (1×, #[1]); Toggle [NR+,PRE-,WAH-] |
+| `gp200-capture-20260412-143836.pcap` | 988 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-150422.pcap` | 533 KB | 1015 | Preset-Read/State-Dump (117 Presets); CMD 12 sub 18 ×74 |
+| `gp200-capture-20260412-150544.pcap` | 628 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-150741.pcap` | 731 KB | 0 | leer / kein GP-200 SysEx |
+| `gp200-capture-20260412-150809.pcap` | 14 KB | 51 | CMD 12 sub 18 ×49 |
+
+### 2026-05-18
+
+| Datei | Größe | Msgs | Kategorie |
+|-------|-------|-----:|-----------|
+| `gp200-capture-20260518-075745.pcap` | 10 KB | 21 | CMD 12 sub 20 ×10; param/effect-change or controller assignment (sub=0x14, 54B raw) ×10 |
+| `gp200-capture-20260518-075856.pcap` | 14 KB | 41 | Preset-Change (1×, #[1]); Toggle [PRE-,RVB+,WAH-]; CMD 12 sub 20 ×18; param/effect-change or controller assignment (sub=0x14, 54B raw) ×18; CMD 12 sub 18 ×1 |
+
+## Protokoll-Fingerprint: noch nicht (voll) dekodierte Sub-Commands
+
+| Sub-Command | Hinweis | Vorkommen | Richtung | Payload-Längen | # Captures |
+|-------------|---------|----------:|----------|----------------|-----------:|
+| `cmd12_sub18` | — | 3186 | D+H | 52 | 43 |
+| `cmd12_sub1C` | IR/NAM multi-chunk upload (sub=0x1C) | 975 | D+H | 60,200,340,370 | 26 |
+| `cmd11_sub1C` | — | 408 | H | 60 | 12 |
+| `cmd12_sub14` | param/effect-change or controller assignment (sub=0x14, 54B raw) | 324 | D+H | 44 | 31 |
+| `cmd11_sub18` | — | 161 | H | 52 | 8 |
+| `cmd11_sub04` | — | 82 | H | 12 | 13 |
+| `cmd12_sub0C` | — | 80 | D | 28,58 | 24 |
+| `cmd12_sub08` | — | 78 | D | 50,66,80,96,110,112,142 | 31 |
+| `cmd12_sub4E` | state-dump chunk (sub=0x4E) | 70 | D | 216,374 | 12 |
+| `cmd12_sub20` | — | 44 | H | 68 | 7 |
+| `cmd11_sub12` | — | 38 | H | 4 | 13 |
+| `cmd12_sub12` | — | 23 | D+H | 4,5 | 2 |
+| `cmd11_sub0A` | — | 15 | H | 24 | 12 |
+| `cmd12_sub0A` | — | 15 | D | 24 | 12 |
+| `cmd12_sub38` | — | 2 | H | 116 | 2 |
+| `cmd12_sub04` | — | 1 | H | 12 | 1 |
+
+Richtung: `H` = Host→Device, `D` = Device→Host.
+
+---
+
+Verwandt: [`sysex-protocol.md`](sysex-protocol.md) · [`capture-todo.md`](capture-todo.md)

--- a/docs/capture-todo.md
+++ b/docs/capture-todo.md
@@ -15,6 +15,9 @@ Dieses Format brauchen wir für:
 
 ### Capture-Anleitung
 
+> Einfachste Variante: das GUI-Tool `scripts/gp200-capture-gui.py` —
+> siehe [`capture-tool.md`](capture-tool.md). Manuell mit Wireshark:
+
 1. Wireshark + USBPcap starten (wie bei den anderen Captures)
 2. GP-200 per USB verbinden
 3. Valeton GP-200 Editor öffnen

--- a/docs/capture-tool.md
+++ b/docs/capture-tool.md
@@ -1,0 +1,151 @@
+# GP-200 USB-Capture Tool — Anleitung
+
+Mit diesem Tool nimmst du die USB-Kommunikation zwischen deinem PC und dem
+Valeton GP-200 auf. Solche Aufnahmen (**Captures**, `.pcap`-Dateien) helfen den
+Entwicklern, **Probleme nachzuvollziehen** — z. B. wenn das Live-USB-Editing
+nicht funktioniert, ein Preset nicht korrekt geschrieben wird oder ein IR/NAM
+nicht lädt.
+
+Es gibt zwei Varianten — beide nehmen dasselbe auf:
+
+| Variante | Datei | Für wen |
+|----------|-------|---------|
+| **GUI (empfohlen)** | `scripts/gp200-capture-gui.py` | Anwender, keine Kommandozeile nötig |
+| Kommandozeile | `scripts/capture-windows.ps1` | Power-User / Skripting |
+
+Analysiert werden die Aufnahmen mit `scripts/analyze-sysex.py`; eine Übersicht
+aller vorhandenen Captures steht in [`capture-catalog.md`](capture-catalog.md).
+
+---
+
+## 1. Voraussetzungen / Installation
+
+Es werden **keine pip-Pakete** benötigt — nur zwei Programme:
+
+### a) Wireshark mit TShark + USBPcap
+
+Das Tool nutzt im Hintergrund `tshark` (Teil von Wireshark) sowie den
+USB-Mitschnitt-Treiber `USBPcap`.
+
+**Windows:**
+1. Wireshark herunterladen: <https://www.wireshark.org/download.html>
+2. Im Installer **beide Haken setzen**:
+   - ☑ **TShark**
+   - ☑ **USBPcap** (USB-Capture-Treiber)
+3. Nach der Installation den **PC neu starten** (USBPcap-Treiber wird sonst nicht aktiv).
+
+> Ohne USBPcap erscheinen keine USB-Interfaces — dann lässt sich nichts aufnehmen.
+
+**Linux:**
+```bash
+sudo apt install tshark        # Debian/Ubuntu/Mint
+sudo modprobe usbmon           # USB-Monitoring aktivieren
+sudo usermod -aG wireshark $USER && newgrp wireshark   # Capture ohne root erlauben
+```
+
+### b) Python 3 (mit Tkinter)
+
+- **Windows:** Python von <https://www.python.org/downloads/> installieren —
+  Tkinter ist dort **bereits enthalten**. (Beim Installer „Add python.exe to PATH" ankreuzen.)
+- **Linux:** Tkinter ggf. nachinstallieren:
+  ```bash
+  sudo apt install python3-tk
+  ```
+
+Prüfen:
+```bash
+python --version          # Python 3.x
+python -m tkinter         # öffnet kurz ein kleines Testfenster
+```
+
+---
+
+## 2. Tool starten
+
+**Windows (empfohlen: als Administrator):**
+
+USB-Aufnahmen brauchen i. d. R. Administratorrechte. Am einfachsten:
+PowerShell **als Administrator** öffnen, dann:
+
+```powershell
+cd <projektordner>
+python scripts\gp200-capture-gui.py
+```
+
+Das Tool warnt oben im Fenster, falls es **nicht** als Administrator läuft.
+
+**Linux:**
+```bash
+python3 scripts/gp200-capture-gui.py
+```
+
+---
+
+## 3. Capture durchführen (GUI)
+
+1. **GP-200 per USB anschließen** und einschalten (Normalmodus).
+2. Tool starten — oben muss stehen **„✓ tshark gefunden"**.
+3. **USB-Interface auswählen.** Es werden nur USB-Interfaces gezeigt
+   (Windows: `USBPcap1`, `USBPcap2`, …). Wenn du nicht weißt, welches:
+   nacheinander ausprobieren — beim falschen bleibt die Datei winzig (siehe unten).
+4. **„Problem (kurz)"** eintippen, z. B. `ir-load-crash` — landet im Dateinamen,
+   das erleichtert die Zuordnung.
+5. **„● Aufnahme starten"** klicken.
+6. **Jetzt das Problem reproduzieren** — im Browser-Editor (preset-forge.com)
+   oder in der Valeton-Software die Aktion ausführen, die nicht funktioniert
+   (Effekt wechseln, Preset speichern, IR/NAM laden, …).
+   Möglichst **kurz** halten und nur die problematische Aktion machen.
+7. **„■ Aufnahme stoppen"** klicken.
+8. Das Tool zeigt den **Speicherort** und die **Dateigröße** an.
+   Über **„Analysieren"** kannst du dir eine Kurzauswertung ansehen,
+   über **„Ordner öffnen"** den Speicherort öffnen.
+
+**Speicherort:** standardmäßig dein **Desktop**, Dateiname
+`gp200-capture-JJJJMMTT-HHMMSS[-beschreibung].pcap`.
+
+---
+
+## 4. Capture an die Entwickler schicken
+
+- **GitHub-Issue (bevorzugt):** <https://github.com/phash/gp200editor/issues> →
+  „New Issue" → Problem beschreiben und die `.pcap`-Datei anhängen.
+- **E-Mail:** Datei an den im Repository angegebenen Kontakt senden.
+
+Bitte dazuschreiben: **was** du getan hast, **was** passieren sollte und **was**
+stattdessen passiert ist, sowie deine **Firmware-Version** (GP-200: 1.8.0 wird unterstützt).
+
+> Eine `.pcap` enthält nur die USB-MIDI-Kommunikation mit dem Pedal
+> (Preset-/Effektdaten). Keine persönlichen Dateien.
+
+---
+
+## 5. Problembehebung
+
+| Symptom | Ursache / Lösung |
+|---------|------------------|
+| „✗ tshark NICHT gefunden" | Wireshark mit **TShark** installieren; danach Tool neu starten |
+| Keine USB-Interfaces in der Liste | **USBPcap** nicht installiert oder PC nach Installation nicht neu gestartet. Notfalls Haken „nur USB-Interfaces" entfernen |
+| Datei ist winzig (< 2 KB) | Falsches Interface erwischt — anderes `USBPcap`-Interface wählen und erneut aufnehmen |
+| „Nicht als Administrator gestartet" | PowerShell als Administrator öffnen und Tool erneut starten |
+| Fenster öffnet nicht (Linux) | `sudo apt install python3-tk` |
+
+---
+
+## 6. Alternative: Kommandozeile
+
+Ohne GUI geht es auch direkt:
+
+```powershell
+# Windows: aufnehmen (interaktive Interface-Auswahl, PowerShell als Administrator)
+.\scripts\capture-windows.ps1
+```
+```bash
+# Linux: aufnehmen
+sudo modprobe usbmon
+tshark -i usbmon3 -w capture.pcap     # Bus-Nr. aus: lsusb | grep -i valeton
+
+# auswerten
+python scripts/analyze-sysex.py capture.pcap
+```
+
+Siehe auch: [`sysex-protocol.md`](sysex-protocol.md) · [`capture-todo.md`](capture-todo.md) · [`capture-catalog.md`](capture-catalog.md)

--- a/docs/sysex-protocol.md
+++ b/docs/sysex-protocol.md
@@ -834,10 +834,18 @@ Large payloads indicate preset write data, not reorder/author.
 | 143029 | -- | Author "Manuel", Style "Green Day", Note "TestNote" |
 | 222343 | -- | Preset Change (slot switch) |
 
-Captures are located in `scripts/gp200-capture-*.pcap`. Analyze with:
+Captures are located in `scripts/gp200-capture-*.pcap`. Analyze a single file with:
 
 ```bash
 python scripts/analyze-sysex.py <capture.pcap>
+```
+
+A **full auto-generated catalog of every local capture** (categorised by SysEx
+content, plus a protocol fingerprint of all undecoded sub-commands) is at
+[`capture-catalog.md`](capture-catalog.md). Regenerate it with:
+
+```bash
+python scripts/build-capture-catalog.py
 ```
 
 ---

--- a/scripts/build-capture-catalog.py
+++ b/scripts/build-capture-catalog.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+GP-200 Capture Catalog Builder
+==============================
+Walks every USB-MIDI capture (``scripts/*.pcap`` + ``caps/*.pcap``), runs each
+through the canonical SysEx analyzer (``analyze-sysex.py`` — reused, not copied)
+and writes a human-readable knowledge-base catalog to ``docs/capture-catalog.md``.
+
+The catalog categorises every capture by SysEx content (toggle, param/effect
+change, preset write/read, preset change, drum, IR/NAM upload, state dump, …)
+and lists every still-undecoded sub-command as a "protocol fingerprint" so the
+open protocol gaps are easy to find.
+
+Usage:
+  python scripts/build-capture-catalog.py            # full run, all captures
+  python scripts/build-capture-catalog.py --quick    # skip captures > 25 MB (fast preview)
+
+Note: the .pcap binaries themselves are NOT in git (see .gitignore). This script
+regenerates the catalog from whatever captures are present locally.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPT_DIR)
+CATALOG_MD = os.path.join(REPO_ROOT, "docs", "capture-catalog.md")
+
+# ---- Reuse the canonical analyzer (filename has a hyphen → load by path) -----
+
+def _load_analyzer():
+    path = os.path.join(SCRIPT_DIR, "analyze-sysex.py")
+    spec = importlib.util.spec_from_file_location("analyze_sysex", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+AZX = _load_analyzer()
+
+# Friendly labels for the cmd/sub combos the analyzer leaves as "unknown_*".
+# These are the still-undecoded (or only partly decoded) parts of the protocol.
+UNKNOWN_HINTS = {
+    "cmd12_sub14": "param/effect-change or controller assignment (sub=0x14, 54B raw)",
+    "cmd12_sub1C": "IR/NAM multi-chunk upload (sub=0x1C)",
+    "cmd11_sub14": "effect-change request (sub=0x14)",
+    "cmd12_sub4E": "state-dump chunk (sub=0x4E)",
+    "cmd11_sub08": "preset-change request (sub=0x08)",
+}
+
+FNAME_RE = re.compile(r"gp200-capture-(\d{8})-(\d{6})\.pcap$")
+
+
+def human_size(num_bytes: int) -> str:
+    mb = num_bytes / 1048576
+    if mb >= 1:
+        return f"{mb:.1f} MB"
+    return f"{num_bytes / 1024:.0f} KB"
+
+
+def summarize(path: str) -> dict:
+    """Run the analyzer over one capture and produce a compact summary dict."""
+    messages = AZX.parse_messages(path)
+
+    type_counts: Counter = Counter()
+    dirs: Counter = Counter()
+    toggle_blocks: set = set()
+    preset_nums: set = set()
+    unknown: dict = defaultdict(lambda: {"count": 0, "dirs": set(), "lens": set()})
+
+    for m in messages:
+        t = m.get("type", "?")
+        type_counts[t] += 1
+        dirs[m.get("direction", "?")] += 1
+        if t in ("toggle_fx", "fx_state_resp", "req_fx_state"):
+            bn = m.get("block_name")
+            st = m.get("state")
+            if bn:
+                toggle_blocks.add(f"{bn}{'+' if st else '-'}" if st is not None else bn)
+        if t in ("change_preset", "req_patch", "req_patch_name") and "preset_num" in m:
+            preset_nums.add(m["preset_num"])
+        if t.startswith("unknown_"):
+            key = t.replace("unknown_", "")
+            u = unknown[key]
+            u["count"] += 1
+            u["dirs"].add("H" if m.get("direction") == "host->dev" else "D")
+            u["lens"].add(len(m.get("payload", b"")))
+
+    # Preset write reconstruction (sub=0x20 chunks → names)
+    write_slots: set = set()
+    write_names: list = []
+    try:
+        for slot, data in AZX.reconstruct_preset(messages).items():
+            write_slots.add(slot)
+            name = data[36:68].split(b"\x00")[0].decode("ascii", "replace").strip()
+            if name:
+                write_names.append(name)
+    except Exception:
+        pass
+
+    # Preset read groups (sub=0x18 chunks)
+    read_groups = 0
+    read_names: list = []
+    try:
+        rp = AZX.decode_all_read_presets(messages)
+        read_groups = len(rp)
+        for _, data in list(rp.items())[:3]:
+            nm = data[28:60].split(b"\x00")[0].decode("ascii", "replace").strip()
+            if nm:
+                read_names.append(nm)
+    except Exception:
+        pass
+
+    return {
+        "path": path,
+        "size": os.path.getsize(path),
+        "n_msgs": len(messages),
+        "types": type_counts,
+        "dirs": dirs,
+        "toggle_blocks": toggle_blocks,
+        "preset_nums": preset_nums,
+        "write_slots": write_slots,
+        "write_names": write_names,
+        "read_groups": read_groups,
+        "read_names": read_names,
+        "unknown": dict(unknown),
+    }
+
+
+def categorize(s: dict) -> str:
+    """Derive a short human category label from a summary dict."""
+    if s["n_msgs"] == 0:
+        return "leer / kein GP-200 SysEx"
+
+    parts: list[str] = []
+    t = s["types"]
+
+    if s["write_slots"]:
+        name = f" '{s['write_names'][0]}'" if s["write_names"] else ""
+        parts.append(f"Preset-Write → Slot {sorted(s['write_slots'])}{name}")
+    if s["read_groups"]:
+        parts.append(f"Preset-Read/State-Dump ({s['read_groups']} Presets)")
+    if t.get("change_preset"):
+        nums = sorted(s["preset_nums"])
+        parts.append(f"Preset-Change ({t['change_preset']}×{', #' + str(nums) if nums else ''})")
+    if t.get("toggle_fx"):
+        blocks = ",".join(sorted(s["toggle_blocks"])) or "?"
+        parts.append(f"Toggle [{blocks}]")
+
+    # Undecoded streams (the interesting research material)
+    for key, info in sorted(s["unknown"].items(), key=lambda kv: -kv[1]["count"]):
+        hint = UNKNOWN_HINTS.get(key, key.replace("cmd", "CMD ").replace("_sub", " sub "))
+        parts.append(f"{hint} ×{info['count']}")
+
+    if not parts:
+        # Only requests / capabilities / handshake traffic
+        if t.get("capabilities") or t.get("req_fx_state") or t.get("req_patch"):
+            parts.append("Handshake / Requests")
+        else:
+            parts.append(", ".join(f"{k}×{v}" for k, v in t.most_common(3)))
+
+    return "; ".join(parts)
+
+
+def main() -> None:
+    quick = "--quick" in sys.argv
+
+    files = []
+    for d in ("scripts", "caps"):
+        dd = os.path.join(REPO_ROOT, d)
+        if not os.path.isdir(dd):
+            continue
+        for fn in os.listdir(dd):
+            if fn.endswith(".pcap"):
+                files.append(os.path.join(dd, fn))
+    files.sort()
+
+    summaries = []
+    for i, path in enumerate(files, 1):
+        size = os.path.getsize(path)
+        if quick and size > 25 * 1048576:
+            print(f"[{i}/{len(files)}] SKIP (quick, {human_size(size)}): {os.path.basename(path)}")
+            continue
+        print(f"[{i}/{len(files)}] {os.path.basename(path)} ({human_size(size)}) ...", flush=True)
+        try:
+            summaries.append(summarize(path))
+        except Exception as e:  # noqa: BLE001 — one bad capture must not abort the run
+            print(f"    FEHLER: {e}", file=sys.stderr)
+
+    write_markdown(summaries, quick)
+    print(f"\nKatalog geschrieben: {CATALOG_MD}  ({len(summaries)} Captures)")
+
+
+def _table(rows: list[dict]) -> list[str]:
+    out = ["| Datei | Größe | Msgs | Kategorie |", "|-------|-------|-----:|-----------|"]
+    for s in rows:
+        out.append(
+            f"| `{os.path.basename(s['path'])}` | {human_size(s['size'])} "
+            f"| {s['n_msgs']} | {categorize(s)} |"
+        )
+    return out
+
+
+def write_markdown(summaries: list[dict], quick: bool) -> None:
+    caps = [s for s in summaries if os.path.sep + "caps" + os.path.sep in s["path"]]
+    scripts = [s for s in summaries if s not in caps]
+
+    total_size = sum(s["size"] for s in summaries)
+    total_msgs = sum(s["n_msgs"] for s in summaries)
+
+    # Aggregate undecoded sub-commands across all captures
+    fingerprint: dict = defaultdict(lambda: {"count": 0, "files": [], "dirs": set(), "lens": set()})
+    for s in summaries:
+        for key, info in s["unknown"].items():
+            fp = fingerprint[key]
+            fp["count"] += info["count"]
+            fp["files"].append(os.path.basename(s["path"]))
+            fp["dirs"] |= info["dirs"]
+            fp["lens"] |= info["lens"]
+
+    lines: list[str] = []
+    lines.append("# GP-200 Capture Catalog")
+    lines.append("")
+    lines.append(
+        "Auto-generierter Katalog aller lokalen USB-MIDI Captures. "
+        "Erzeugt mit `python scripts/build-capture-catalog.py` (nutzt `analyze-sysex.py`)."
+    )
+    lines.append("")
+    lines.append(
+        "> ⚠️ Die `.pcap`-Rohdaten sind **nicht** im Git-Repo (`scripts/*.pcap` untracked, "
+        "`caps/` in `.gitignore`). Dieser Katalog ist die durchsuchbare Übersicht; die Binärdaten "
+        "liegen nur lokal / im Backup."
+    )
+    lines.append("")
+    lines.append(f"- **Captures:** {len(summaries)}" + ("  _(--quick: große Dateien übersprungen)_" if quick else ""))
+    lines.append(f"- **Gesamtgröße:** {human_size(total_size)}")
+    lines.append(f"- **SysEx-Nachrichten gesamt:** {total_msgs}")
+    lines.append("")
+    lines.append("Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`")
+    lines.append("")
+
+    if caps:
+        lines.append("## Benannte Captures (`caps/`)")
+        lines.append("")
+        lines += _table(sorted(caps, key=lambda s: s["path"]))
+        lines.append("")
+
+    if scripts:
+        lines.append("## Zeitstempel-Captures (`scripts/`)")
+        lines.append("")
+        # group by capture date parsed from filename
+        by_date: dict = defaultdict(list)
+        for s in scripts:
+            m = FNAME_RE.search(s["path"])
+            day = m.group(1) if m else "????????"
+            by_date[day].append(s)
+        for day in sorted(by_date):
+            pretty = f"{day[0:4]}-{day[4:6]}-{day[6:8]}" if day != "????????" else "unbekannt"
+            lines.append(f"### {pretty}")
+            lines.append("")
+            lines += _table(sorted(by_date[day], key=lambda s: s["path"]))
+            lines.append("")
+
+    lines.append("## Protokoll-Fingerprint: noch nicht (voll) dekodierte Sub-Commands")
+    lines.append("")
+    if fingerprint:
+        lines.append("| Sub-Command | Hinweis | Vorkommen | Richtung | Payload-Längen | # Captures |")
+        lines.append("|-------------|---------|----------:|----------|----------------|-----------:|")
+        for key, fp in sorted(fingerprint.items(), key=lambda kv: -kv[1]["count"]):
+            hint = UNKNOWN_HINTS.get(key, "—")
+            dirs = "+".join(sorted(fp["dirs"])) or "?"
+            lens = ",".join(str(x) for x in sorted(fp["lens"])[:8])
+            lines.append(
+                f"| `{key}` | {hint} | {fp['count']} | {dirs} | {lens} | {len(fp['files'])} |"
+            )
+        lines.append("")
+        lines.append("Richtung: `H` = Host→Device, `D` = Device→Host.")
+    else:
+        lines.append("_Keine undekodierten Sub-Commands gefunden._")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("Verwandt: [`sysex-protocol.md`](sysex-protocol.md) · [`capture-todo.md`](capture-todo.md)")
+    lines.append("")
+
+    os.makedirs(os.path.dirname(CATALOG_MD), exist_ok=True)
+    with open(CATALOG_MD, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gp200-capture-gui.py
+++ b/scripts/gp200-capture-gui.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""
+GP-200 Capture GUI
+==================
+Kleines grafisches Tool, um eine USB-MIDI-Aufnahme (Capture) des Valeton GP-200
+ohne Kommandozeile durchzuführen. Gedacht für Anwender, die ein Problem mit dem
+Editor / der Live-USB-Verbindung haben und den Entwicklern eine Aufnahme schicken
+möchten.
+
+Es ist die GUI-Variante von ``capture-windows.ps1`` und nutzt darunter dasselbe
+``tshark`` (Wireshark). Es werden KEINE pip-Pakete benötigt — nur Python 3 mit
+Tkinter (Standardbibliothek) und eine Wireshark-Installation mit tshark + USBPcap.
+
+Start:
+  python scripts/gp200-capture-gui.py        (Windows: am besten "als Administrator")
+
+Ablauf:
+  1. GP-200 per USB anschließen und einschalten
+  2. Tool starten, USB-Interface auswählen
+  3. (Optional) kurze Problembeschreibung eintippen → landet im Dateinamen
+  4. "Aufnahme starten" → im Browser-Editor / in der Valeton-Software das Problem
+     reproduzieren → "Aufnahme stoppen"
+  5. Die .pcap-Datei den Entwicklern schicken (GitHub-Issue / E-Mail)
+
+Anleitung mit Installation: docs/capture-tool.md
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import signal
+import subprocess
+import sys
+from datetime import datetime
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPT_DIR)
+IS_WINDOWS = sys.platform == "win32"
+
+
+# ---- tshark discovery (reuse analyze-sysex.py, fall back to inline) ----------
+
+def _find_tshark() -> str | None:
+    """Locate tshark. Reuses analyze-sysex.find_tshark when importable."""
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "analyze_sysex", os.path.join(SCRIPT_DIR, "analyze-sysex.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        # analyze-sysex.find_tshark exits the process if not found, so guard it
+        candidates = ["tshark"]
+        if IS_WINDOWS:
+            candidates += [
+                r"C:\Program Files\Wireshark\tshark.exe",
+                r"C:\Program Files (x86)\Wireshark\tshark.exe",
+            ]
+        for c in candidates:
+            try:
+                subprocess.run([c, "--version"], capture_output=True, check=True)
+                return c
+            except (FileNotFoundError, subprocess.CalledProcessError):
+                continue
+    except Exception:
+        pass
+    return None
+
+
+def _is_admin() -> bool:
+    if not IS_WINDOWS:
+        return os.geteuid() == 0 if hasattr(os, "geteuid") else True
+    try:
+        import ctypes
+
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except Exception:
+        return False
+
+
+def _slugify(text: str) -> str:
+    text = text.strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")[:40]
+
+
+# ---- GUI --------------------------------------------------------------------
+
+class CaptureApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("GP-200 USB-Capture")
+        self.geometry("680x620")
+        self.minsize(620, 560)
+
+        self.tshark = _find_tshark()
+        self.proc: subprocess.Popen | None = None
+        self.out_file: str | None = None
+        self.start_time: datetime | None = None
+        self._poll_job: str | None = None
+
+        self.interfaces: list[tuple[str, str]] = []  # (id, description)
+
+        self._build_ui()
+        self._refresh_status()
+        if self.tshark:
+            self.refresh_interfaces()
+
+    # -- layout ---------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        pad = dict(padx=10, pady=4)
+
+        header = ttk.Label(
+            self,
+            text="GP-200 USB-Capture",
+            font=("Segoe UI", 16, "bold"),
+        )
+        header.pack(anchor="w", padx=10, pady=(10, 0))
+
+        intro = ttk.Label(
+            self,
+            text=(
+                "Nimmt die USB-Kommunikation zwischen PC und GP-200 auf, damit "
+                "Entwickler ein Problem nachvollziehen können.\n"
+                "GP-200 anschließen → Interface wählen → Aufnahme starten → Problem "
+                "reproduzieren → stoppen → Datei einsenden."
+            ),
+            wraplength=640,
+            justify="left",
+        )
+        intro.pack(anchor="w", **pad)
+
+        # Status box
+        self.status_var = tk.StringVar()
+        status = ttk.Label(self, textvariable=self.status_var, wraplength=640, justify="left")
+        status.pack(anchor="w", **pad)
+
+        # Interface selection
+        ifrm = ttk.LabelFrame(self, text="USB-Interface")
+        ifrm.pack(fill="x", **pad)
+        self.iface_var = tk.StringVar()
+        self.iface_combo = ttk.Combobox(ifrm, textvariable=self.iface_var, state="readonly", width=60)
+        self.iface_combo.grid(row=0, column=0, padx=6, pady=6, sticky="we")
+        self.usb_only = tk.BooleanVar(value=True)
+        ttk.Checkbutton(
+            ifrm, text="nur USB-Interfaces", variable=self.usb_only, command=self.refresh_interfaces
+        ).grid(row=0, column=1, padx=6)
+        ttk.Button(ifrm, text="Aktualisieren", command=self.refresh_interfaces).grid(
+            row=0, column=2, padx=6
+        )
+        ifrm.columnconfigure(0, weight=1)
+
+        # Output folder + description
+        ofrm = ttk.LabelFrame(self, text="Speicherort & Beschreibung")
+        ofrm.pack(fill="x", **pad)
+        default_dir = self._default_outdir()
+        self.dir_var = tk.StringVar(value=default_dir)
+        ttk.Label(ofrm, text="Ordner:").grid(row=0, column=0, sticky="w", padx=6, pady=4)
+        ttk.Entry(ofrm, textvariable=self.dir_var).grid(row=0, column=1, sticky="we", padx=6)
+        ttk.Button(ofrm, text="…", width=3, command=self._choose_dir).grid(row=0, column=2, padx=6)
+        ttk.Label(ofrm, text="Problem (kurz):").grid(row=1, column=0, sticky="w", padx=6, pady=4)
+        self.desc_var = tk.StringVar()
+        ttk.Entry(ofrm, textvariable=self.desc_var).grid(row=1, column=1, sticky="we", padx=6)
+        ttk.Label(ofrm, text="z. B. ir-load-crash", foreground="gray").grid(
+            row=1, column=2, sticky="w", padx=6
+        )
+        ofrm.columnconfigure(1, weight=1)
+
+        # Big start/stop button
+        self.action_btn = ttk.Button(self, text="● Aufnahme starten", command=self.toggle_capture)
+        self.action_btn.pack(fill="x", padx=10, pady=8)
+
+        self.timer_var = tk.StringVar(value="")
+        ttk.Label(self, textvariable=self.timer_var, font=("Consolas", 11)).pack(anchor="w", padx=10)
+
+        # Log
+        self.log = scrolledtext.ScrolledText(self, height=12, state="disabled", wrap="word")
+        self.log.pack(fill="both", expand=True, padx=10, pady=(4, 6))
+
+        # Post-capture actions
+        self.post_frame = ttk.Frame(self)
+        self.post_frame.pack(fill="x", padx=10, pady=(0, 10))
+        self.analyze_btn = ttk.Button(
+            self.post_frame, text="Analysieren", command=self._analyze, state="disabled"
+        )
+        self.analyze_btn.pack(side="left")
+        self.open_btn = ttk.Button(
+            self.post_frame, text="Ordner öffnen", command=self._open_folder, state="disabled"
+        )
+        self.open_btn.pack(side="left", padx=6)
+
+    # -- helpers --------------------------------------------------------------
+
+    def _default_outdir(self) -> str:
+        desktop = os.path.join(os.path.expanduser("~"), "Desktop")
+        return desktop if os.path.isdir(desktop) else os.path.expanduser("~")
+
+    def _log(self, msg: str) -> None:
+        self.log.configure(state="normal")
+        self.log.insert("end", msg + "\n")
+        self.log.see("end")
+        self.log.configure(state="disabled")
+
+    def _refresh_status(self) -> None:
+        lines = []
+        if self.tshark:
+            lines.append(f"✓ tshark gefunden: {self.tshark}")
+        else:
+            lines.append(
+                "✗ tshark NICHT gefunden. Bitte Wireshark mit 'TShark' + 'USBPcap' installieren "
+                "(siehe docs/capture-tool.md)."
+            )
+        if IS_WINDOWS and not _is_admin():
+            lines.append(
+                "⚠ Nicht als Administrator gestartet — USB-Aufnahme braucht meist Admin-Rechte."
+            )
+        self.status_var.set("\n".join(lines))
+        self.action_btn.configure(state="normal" if self.tshark else "disabled")
+
+    def _choose_dir(self) -> None:
+        d = filedialog.askdirectory(initialdir=self.dir_var.get() or os.path.expanduser("~"))
+        if d:
+            self.dir_var.set(d)
+
+    # -- interfaces -----------------------------------------------------------
+
+    def refresh_interfaces(self) -> None:
+        if not self.tshark:
+            return
+        try:
+            res = subprocess.run([self.tshark, "-D"], capture_output=True, text=True)
+        except Exception as e:  # noqa: BLE001
+            self._log(f"Interface-Liste fehlgeschlagen: {e}")
+            return
+        self.interfaces = []
+        for line in res.stdout.splitlines():
+            m = re.match(r"^\s*(\d+)\.\s+(\S+)\s*(?:\((.*)\))?", line)
+            if not m:
+                continue
+            idx, ident, desc = m.group(1), m.group(2), (m.group(3) or "")
+            label = f"{idx}: {desc or ident}"
+            is_usb = ("usbpcap" in line.lower()) or ("usbmon" in line.lower())
+            if self.usb_only.get() and not is_usb:
+                continue
+            self.interfaces.append((idx, label))
+        values = [lbl for _, lbl in self.interfaces]
+        self.iface_combo.configure(values=values)
+        if values:
+            self.iface_combo.current(0)
+            self._log(f"{len(values)} Interface(s) gefunden.")
+        else:
+            self._log(
+                "Keine USB-Interfaces gefunden. USBPcap installiert? "
+                "Haken 'nur USB-Interfaces' entfernen, um alle zu sehen."
+            )
+
+    def _selected_iface_id(self) -> str | None:
+        sel = self.iface_var.get()
+        for idx, lbl in self.interfaces:
+            if lbl == sel:
+                return idx
+        return None
+
+    # -- capture --------------------------------------------------------------
+
+    def toggle_capture(self) -> None:
+        if self.proc is None:
+            self.start_capture()
+        else:
+            self.stop_capture()
+
+    def start_capture(self) -> None:
+        iface = self._selected_iface_id()
+        if not iface:
+            messagebox.showwarning("Kein Interface", "Bitte zuerst ein USB-Interface auswählen.")
+            return
+        out_dir = self.dir_var.get().strip() or self._default_outdir()
+        try:
+            os.makedirs(out_dir, exist_ok=True)
+        except Exception as e:  # noqa: BLE001
+            messagebox.showerror("Ordner", f"Ordner nicht nutzbar:\n{e}")
+            return
+
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        slug = _slugify(self.desc_var.get())
+        name = f"gp200-capture-{ts}{('-' + slug) if slug else ''}.pcap"
+        self.out_file = os.path.join(out_dir, name)
+
+        cmd = [self.tshark, "-i", iface, "-w", self.out_file]
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0
+        try:
+            self.proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=creationflags,
+            )
+        except Exception as e:  # noqa: BLE001
+            messagebox.showerror("Start fehlgeschlagen", str(e))
+            self.proc = None
+            return
+
+        self.start_time = datetime.now()
+        self.action_btn.configure(text="■ Aufnahme stoppen")
+        self.analyze_btn.configure(state="disabled")
+        self.open_btn.configure(state="disabled")
+        self._set_inputs_state("disabled")
+        self._log("")
+        self._log(f"▶ Aufnahme läuft → {self.out_file}")
+        self._log("   Jetzt im Editor / in der Valeton-Software das Problem reproduzieren.")
+        self._poll()
+
+    def stop_capture(self) -> None:
+        if self.proc is None:
+            return
+        self._log("■ Stoppe Aufnahme …")
+        try:
+            if IS_WINDOWS:
+                # Clean stop so tshark flushes the final pcap block.
+                self.proc.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                self.proc.terminate()
+            self.proc.wait(timeout=8)
+        except Exception:
+            try:
+                self.proc.kill()
+            except Exception:
+                pass
+        self.proc = None
+        if self._poll_job:
+            self.after_cancel(self._poll_job)
+            self._poll_job = None
+        self.action_btn.configure(text="● Aufnahme starten")
+        self._set_inputs_state("normal")
+
+        if self.out_file and os.path.exists(self.out_file):
+            size = os.path.getsize(self.out_file)
+            self._log(f"✓ Gespeichert: {self.out_file}  ({size/1024:.0f} KB)")
+            self._log("→ Diese Datei den Entwicklern schicken (GitHub-Issue oder E-Mail).")
+            self.analyze_btn.configure(state="normal")
+            self.open_btn.configure(state="normal")
+            if size < 2048:
+                self._log(
+                    "⚠ Datei ist sehr klein — evtl. falsches Interface? "
+                    "Anderes USB-Interface probieren und erneut aufnehmen."
+                )
+        else:
+            self._log("✗ Keine Datei erzeugt. Falsches Interface oder fehlende Rechte?")
+
+    def _set_inputs_state(self, state: str) -> None:
+        self.iface_combo.configure(state="readonly" if state == "normal" else "disabled")
+
+    def _poll(self) -> None:
+        if self.proc is None:
+            return
+        if self.start_time:
+            elapsed = (datetime.now() - self.start_time).total_seconds()
+            size = os.path.getsize(self.out_file) if (self.out_file and os.path.exists(self.out_file)) else 0
+            self.timer_var.set(f"⏱  {int(elapsed)}s   ·   {size/1024:.0f} KB aufgenommen")
+        if self.proc.poll() is not None:
+            # tshark exited on its own (e.g. error)
+            self._log("tshark wurde beendet.")
+            self.stop_capture()
+            return
+        self._poll_job = self.after(500, self._poll)
+
+    # -- post actions ---------------------------------------------------------
+
+    def _analyze(self) -> None:
+        if not self.out_file:
+            return
+        analyzer = os.path.join(SCRIPT_DIR, "analyze-sysex.py")
+        if not os.path.exists(analyzer):
+            messagebox.showinfo("Analyse", "analyze-sysex.py nicht gefunden.")
+            return
+        self._log("")
+        self._log("--- Analyse (analyze-sysex.py) ---")
+        try:
+            res = subprocess.run(
+                [sys.executable, analyzer, self.out_file],
+                capture_output=True, text=True,
+            )
+            out = res.stdout.strip() or res.stderr.strip()
+            # show a compact head so the log stays readable
+            for line in out.splitlines()[:40]:
+                self._log(line)
+            if len(out.splitlines()) > 40:
+                self._log(f"… (gekürzt, volle Ausgabe via: python scripts/analyze-sysex.py \"{self.out_file}\")")
+        except Exception as e:  # noqa: BLE001
+            self._log(f"Analyse fehlgeschlagen: {e}")
+
+    def _open_folder(self) -> None:
+        if not self.out_file:
+            return
+        folder = os.path.dirname(self.out_file)
+        try:
+            if IS_WINDOWS:
+                os.startfile(folder)  # noqa: S606
+            elif sys.platform == "darwin":
+                subprocess.run(["open", folder])
+            else:
+                subprocess.run(["xdg-open", folder])
+        except Exception as e:  # noqa: BLE001
+            self._log(f"Ordner öffnen fehlgeschlagen: {e}")
+
+
+def main() -> None:
+    app = CaptureApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Was

Knowledge base rund um die GP-200 USB-MIDI Captures + ein einfaches Tool, mit dem auch Endanwender ein Capture ihres Problems erzeugen können.

### Neu
- **`docs/capture-catalog.md`** — auto-generierter Katalog **aller 130 lokalen Captures**, kategorisiert nach SysEx-Inhalt (Toggle, Preset-Write/Read, Preset-Change, Param/Effect-Change, IR/NAM-Upload, State-Dump …), plus **Protokoll-Fingerprint** aller noch nicht voll dekodierten Sub-Commands. Macht 36 leere Captures und mutmaßliche Duplikate sichtbar.
- **`scripts/build-capture-catalog.py`** — regeneriert den Katalog, nutzt `analyze-sysex.py` wieder (kein Copy-Paste).
- **`scripts/gp200-capture-gui.py`** — kleines tkinter-GUI für Captures ohne Kommandozeile. Nur Python-Stdlib, **keine pip-Dependencies**. Interface-Auswahl, Problembeschreibung→Dateiname, Start/Stop, Live-Größe/Timer, Analyse-Button, sauberer Stop via CTRL_BREAK.
- **`docs/capture-tool.md`** — Installation (Wireshark + USBPcap + Python/Tkinter), Schritt-für-Schritt, Bug-Report-Workflow, Troubleshooting.

### Geändert
- **`README.md`** — Abschnitt „Reporting a USB problem (send a capture)".
- **`docs/sysex-protocol.md`** / **`docs/capture-todo.md`** — Cross-Links auf Katalog & Tool.

## Hinweis
Die `.pcap`-Rohdaten bleiben bewusst außerhalb von Git (gitignored/untracked, ~620 MB) — der Katalog ist der durchsuchbare Index.

## Verifikation
- `py_compile` beider Skripte OK
- Katalog-Lauf: 130/130 Captures in ~53 s
- GUI: Fenster baut auf, erkennt USBPcap-Interfaces, Mainloop sauber beendet

🤖 Generated with [Claude Code](https://claude.com/claude-code)