### PR TITLE
docs: mark buildEffectChange (sub=0x14) done in capture-todo (#58)

### DIFF
--- a/docs/capture-todo.md
+++ b/docs/capture-todo.md
@@ -5,7 +5,15 @@ Preset Forge kann jetzt Presets auf dem GP-200 speichern (Save-Commit),
 aber **nicht vollständig auf andere Slots schreiben** (Write-Chunks gehen,
 aber Effekt-IDs können nicht geändert werden).
 
-## Was fehlt: buildEffectChange (sub=0x14)
+## ✅ Erledigt: buildEffectChange (sub=0x14)
+
+> **Status: implementiert & hardware-verifiziert** (Issue #58 geschlossen 2026-06-25).
+> Decodiert als `SysExCodec.buildEffectChange` (`src/core/SysExCodec.ts`), gesendet via
+> `sendEffectChange` (`src/hooks/useMidiSend.ts`) und im Write-to-Slot-Pfad
+> (`src/hooks/useMidiDevice.ts`). Unit-Tests in `tests/unit/SysExCodec.test.ts` +
+> `tests/unit/useMidiDevice.test.ts`. Format: raw[38]=block, raw[45:47]=variant
+> (nibble), raw[52]=module type. Am Gerät bestätigt (#80: „manual effect changes work").
+> Die folgende Capture-Anleitung ist nur noch historische Referenz.
 
 Wenn man am Gerät oder in der Valeton-Software einen Effekt in einem Slot
 **austauscht** (z.B. Green OD → Force), sendet die Software sub=0x14 (54 Bytes, raw).
@@ -13,7 +21,7 @@ Dieses Format brauchen wir für:
 - Preset von Datei auf Gerät laden (alle Effekte setzen)
 - Slot-Tausch in der Bank (verschiedene Effekte)
 
-### Capture-Anleitung
+### Capture-Anleitung (historisch)
 
 > Einfachste Variante: das GUI-Tool `scripts/gp200-capture-gui.py` —
 > siehe [`capture-tool.md`](capture-tool.md). Manuell mit Wireshark:


### PR DESCRIPTION
Closes #58.

`buildEffectChange` (sub=0x14) is decoded, implemented, unit-tested and hardware-verified — the issue body was already self-marked ✅ Implemented; only the `capture-todo.md` housekeeping checkbox remained. This updates that section (now "✅ Erledigt", capture notes kept as historical reference).

- `SysExCodec.buildEffectChange` (`src/core/SysExCodec.ts`)
- wired via `sendEffectChange` (`src/hooks/useMidiSend.ts`) + write-to-slot path (`src/hooks/useMidiDevice.ts`)
- tests: `tests/unit/SysExCodec.test.ts`, `tests/unit/useMidiDevice.test.ts`
- HW-verified (#80: romanlefler — "manual effect changes work")

Docs-only, no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)