### PR TITLE
fix(midi): encode param-change display-value field so param 0 lands (#80)

### DIFF
--- a/src/core/SysExCodec.ts
+++ b/src/core/SysExCodec.ts
@@ -2,6 +2,30 @@ import type { GP200Preset } from './types';
 import { GP200PresetSchema } from './types';
 
 export const SysExCodec = {
+  /**
+   * Encode a parameter value into the 2-byte logarithmic "display value" field
+   * that lives at decoded[14:16] of a Param Change message (#80).
+   *
+   * Reverse-engineered from the Valeton knob-sweep capture
+   * (gp200-capture-20260412-143552.pcap): the field is a custom log encoding,
+   * identical across params for the same value, fit (±1 LSB) by
+   *   u16 = round(16367 + 16 * log2(value))
+   * with value <= 0 mapping to 0. Returns [lowByte, highByte] (LE) for
+   * decoded[14], decoded[15].
+   *
+   * The device reads THIS field (not the float32 at [20:24]) for the first
+   * parameter of a block, which is why hardcoding 0x6F there zeroed param 0.
+   */
+  encodeDisplayValue(value: number): Uint8Array {
+    let u16 = 0;
+    if (value > 0) {
+      u16 = Math.round(16367 + 16 * Math.log2(value));
+      if (u16 < 0) u16 = 0;
+      if (u16 > 0xFFFF) u16 = 0xFFFF;
+    }
+    return new Uint8Array([u16 & 0xFF, (u16 >> 8) & 0xFF]);
+  },
+
   nibbleDecode(data: Uint8Array): Uint8Array {
     const out = new Uint8Array(Math.floor(data.length / 2));
     for (let i = 0; i < out.length; i++) {
@@ -478,7 +502,12 @@ export const SysExCodec = {
     decoded[10] = 0x0C;                         // constant
     decoded[12] = blockIndex;                   // 0-10
     decoded[13] = paramIndex;                   // 0-14
-    decoded[14] = 0x6F;                         // marker (0xFA for Combox controls)
+    // decoded[14:16] = logarithmic display-value field. The device reads this
+    // (not the float32 below) for a block's FIRST parameter, so the old constant
+    // 0x6F made param 0 of every effect land at 0 (#80). Encode the real value.
+    const disp = this.encodeDisplayValue(value);
+    decoded[14] = disp[0];
+    decoded[15] = disp[1];
     view.setUint32(16, effectId, true);         // effect code LE
     view.setFloat32(20, value, true);           // parameter value
 

--- a/tests/unit/SysExCodec.test.ts
+++ b/tests/unit/SysExCodec.test.ts
@@ -670,7 +670,10 @@ describe('SysExCodec: buildParamChange', () => {
     expect(decoded[2]).toBe(0x04);
     expect(decoded[8]).toBe(0x05);
     expect(decoded[10]).toBe(0x0C);
-    expect(decoded[14]).toBe(0x6F);
+    // decoded[14:16] = logarithmic display-value field for value 43.0 (#80),
+    // no longer a constant 0x6F marker.
+    expect(decoded[14]).toBe(0x46);
+    expect(decoded[15]).toBe(0x40);
     // Block + param
     expect(decoded[12]).toBe(8);   // DLY
     expect(decoded[13]).toBe(0);   // Mix
@@ -1108,5 +1111,48 @@ describe('SysExCodec: buildWriteChunks fxLoop', () => {
     const decoded = SysExCodec.nibbleDecode(new Uint8Array(allNibbles));
     expect(decoded[114]).toBe(6);
     expect(decoded[115]).toBe(7);
+  });
+});
+
+/**
+ * Param Change display-value field (decoded[14:16]) — #80.
+ *
+ * Decoding the real Valeton knob-sweep capture (gp200-capture-20260412-143552.pcap,
+ * 1086 param writes) showed decoded[14:16] is NOT a constant 0x6F "marker" — it is a
+ * logarithmic display-value field that the device reads for the *first* parameter of a
+ * block. The fit, verified across params 1/5/6 and value range 0..19929 (±1 LSB):
+ *
+ *   u16 = round(16367 + 16 * log2(value)) ; decoded[14]=u16&0xFF, decoded[15]=u16>>8
+ *   value <= 0  ->  u16 = 0
+ *
+ * Hardcoding 0x6F (~value 256 on this scale, which the device remaps toward 0) is why
+ * param 0 of every effect landed at 0 while params 1-14 (read from float32 at [20:24])
+ * were correct.
+ */
+function decodeParamMessage(msg: Uint8Array): Uint8Array {
+  // header is 13 bytes, trailing 0xF7; the rest is nibble-encoded payload
+  return SysExCodec.nibbleDecode(msg.slice(13, msg.length - 1));
+}
+
+describe('SysExCodec: param-change display-value field (#80)', () => {
+  it('encodeDisplayValue matches captured Valeton values', () => {
+    expect(Array.from(SysExCodec.encodeDisplayValue(0))).toEqual([0x00, 0x00]);
+    expect(Array.from(SysExCodec.encodeDisplayValue(27))).toEqual([0x3b, 0x40]);
+    expect(Array.from(SysExCodec.encodeDisplayValue(100))).toEqual([0x59, 0x40]);
+    expect(Array.from(SysExCodec.encodeDisplayValue(56))).toEqual([0x4c, 0x40]);
+  });
+
+  it('encodeDisplayValue falls back to 0x0000 for non-positive values', () => {
+    expect(Array.from(SysExCodec.encodeDisplayValue(-3))).toEqual([0x00, 0x00]);
+    expect(Array.from(SysExCodec.encodeDisplayValue(0))).toEqual([0x00, 0x00]);
+  });
+
+  it('buildParamChange writes the display-value field at decoded[14:16], not a 0x6F marker', () => {
+    const msg = SysExCodec.buildParamChange(0, 0, 0x00000003, 27);
+    const dec = decodeParamMessage(msg);
+    expect(dec[13]).toBe(0);         // param index preserved
+    expect(dec[14]).toBe(0x3b);      // display-value low byte (was hardcoded 0x6F)
+    expect(dec[15]).toBe(0x40);      // display-value high byte (was 0x00)
+    expect(new DataView(dec.buffer).getFloat32(20, true)).toBe(27); // float32 still set
   });
 });


### PR DESCRIPTION
Follow-up to #80. After the 400ms-settle + second-param-pass fix (#82), the reporter narrowed it precisely: the **first parameter of every effect** lands at `0` on the device, overwriting the real value — even though the app sends the correct value twice (verified in his log: pass 1 + pass 2 both show e.g. `block=0 param=0 value=38`).

## Root cause
Decoded the real Valeton knob-sweep capture (`caps/gp200-capture-20260412-143552.pcap`, 1086 param writes). `decoded[14:16]` of a Param Change is **not** a constant `0x6F` "marker" — it's a logarithmic **display-value** field the device reads for a block's **first** parameter. Fit verified across params 1/5/6 over value 0..19929 (±1 LSB):

```
u16 = round(16367 + 16 * log2(value)); decoded[14]=u16&0xFF, decoded[15]=u16>>8
value <= 0 -> 0
```

We hardcoded `0x6F` there (≈ value 256 on this scale → device remaps toward 0), so param 0 always landed at ~0 while params 1-14 (read from float32 at `[20:24]`) were correct. The old "0x6F marker" in our code/docs was itself a mis-read of one capture whose value happened to encode to `0x6F`.

This makes our Param Change message **byte-identical to captured working Valeton traffic**, so it cannot regress params 1-14 (they already worked, and now carry the same field Valeton sends).

## Changes
- new `SysExCodec.encodeDisplayValue(value)` — pure, unit-tested against the capture data points
- `buildParamChange` encodes `decoded[14:16]` instead of `0x6F`
- existing param-change test updated to assert the display-value field

754 unit tests pass, build OK. Hardware verification requested from reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)