### PR TITLE
fix(midi): re-send param 0 at end of each block burst so it lands (#80)

### DIFF
--- a/src/core/devicePush.ts
+++ b/src/core/devicePush.ts
@@ -60,6 +60,15 @@ export async function pushPresetToDevice(
         await sleep(paramGap);
       }
     }
+    // Re-send param 0 at the end of the block's burst. The device swallows the
+    // FIRST param-change of a block (it opens the block's edit context), so
+    // param 0 — always sent first — never lands during a load, even though the
+    // identical message works when sent alone (manual knob edit). Re-sending it
+    // after the others, when the context is already open, makes it stick (#80).
+    if (eff.params.length > 0 && eff.params[0] !== undefined) {
+      sender.sendParamChange(i, 0, eff.effectId, eff.params[0]);
+      await sleep(paramGap);
+    }
   };
 
   // Pass 1: per block — effect type, settle, params, toggle.

--- a/tests/unit/devicePush.test.ts
+++ b/tests/unit/devicePush.test.ts
@@ -49,14 +49,15 @@ describe('pushPresetToDevice', () => {
 
     const nonSleep = events.filter((e) => !e.startsWith('sleep:'));
 
-    // Pass 1 sends fx + params + toggle per block; pass 2 re-sends only params.
-    // Each param must therefore appear exactly twice.
+    // Per block, params go 0..N then param 0 is re-sent at the end (see the
+    // param-0 test below). Both passes do this. So for block 0 ([5,6]) each pass
+    // emits 0,1,0 and for block 1 ([7]) each pass emits 0,0.
     const paramEvents = nonSleep.filter((e) => e.startsWith('param:'));
     expect(paramEvents).toEqual([
-      'param:0:0:5', 'param:0:1:6', // block 0, pass 1
-      'param:1:0:7',                // block 1, pass 1
-      'param:0:0:5', 'param:0:1:6', // block 0, pass 2
-      'param:1:0:7',                // block 1, pass 2
+      'param:0:0:5', 'param:0:1:6', 'param:0:0:5', // block 0, pass 1 (+ re-send p0)
+      'param:1:0:7', 'param:1:0:7',                // block 1, pass 1 (+ re-send p0)
+      'param:0:0:5', 'param:0:1:6', 'param:0:0:5', // block 0, pass 2
+      'param:1:0:7', 'param:1:0:7',                // block 1, pass 2
     ]);
 
     // The whole second pass must come AFTER every effect-change and toggle,
@@ -64,9 +65,25 @@ describe('pushPresetToDevice', () => {
     const lastToggleIdx = nonSleep.map((e) => e.startsWith('toggle:')).lastIndexOf(true);
     const afterToggles = nonSleep.slice(lastToggleIdx + 1);
     expect(afterToggles.filter((e) => e.startsWith('param:'))).toEqual([
-      'param:0:0:5', 'param:0:1:6', 'param:1:0:7',
+      'param:0:0:5', 'param:0:1:6', 'param:0:0:5', 'param:1:0:7', 'param:1:0:7',
     ]);
     expect(afterToggles.some((e) => e.startsWith('fx:') || e.startsWith('toggle:'))).toBe(false);
+  });
+
+  it('re-sends param 0 at the end of each block so it is never the swallowed first message', async () => {
+    const { events, sender, sleep } = makeRecorder();
+    await pushPresetToDevice(twoBlockPreset(), sender, { sleep });
+    const nonSleep = events.filter((e) => !e.startsWith('sleep:'));
+
+    // The device swallows the FIRST param-change of a block's burst (it opens the
+    // block's edit context), so param 0 — always sent first — never lands unless
+    // re-sent. Within block 0's pass-1 params, the sequence must be 0,1,0.
+    const fx0 = nonSleep.indexOf('fx:0:17');
+    const toggle0 = nonSleep.indexOf('toggle:0:true');
+    const block0Params = nonSleep.slice(fx0 + 1, toggle0);
+    expect(block0Params).toEqual(['param:0:0:5', 'param:0:1:6', 'param:0:0:5']);
+    // ...and the last param of that block's burst is param 0 (not param 1).
+    expect(block0Params[block0Params.length - 1]).toBe('param:0:0:5');
   });
 
   it('sends the author last, after both param passes', async () => {


### PR DESCRIPTION
Follow-up to #80 / #84.

## Reporter's decisive bisect
- The earlier display-value change (#84) made **no difference** — so the device does *not* read the value from that field.
- **Manually moving a slider sends the byte-identical param message and it lands correctly.** ("loading sets gain to 0, but touching the slider brings it to the right value.")
- The full log confirms param 0 is sent **twice** (pass 1 + pass 2) with the correct value, and still ends at 0. Pass 2 has no preceding effect-change, so it's not effect-change timing.

## Conclusion
It's not the message format and not effect-change settle. The only thing that distinguishes a failing param 0 from a working one is **position in the burst**: on load, param 0 is always the *first* param-change of a block (followed 8ms later by param 1..14); the manual edit sends param 0 alone.

Best-fit cause: **the device swallows the first param-change of a block's burst** (it opens the block's edit context). param 0 is always first → never lands. params 1-14 survive because param 0 opened the context. Manual works because the context is already open.

## Fix
Re-send param 0 at the **end** of each block's param loop (both passes), so it is no longer the swallowed-first message. Low-risk: one extra, already-correct param 0 write per block; cannot regress params 1-14.

`src/core/devicePush.ts` + test. 755 unit tests pass, build OK. Hardware verification requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)