### PR TITLE
fix(midi): space param writes 40ms apart so the device stops dropping the burst (#80)

### DIFF
--- a/src/core/devicePush.ts
+++ b/src/core/devicePush.ts
@@ -49,7 +49,13 @@ export async function pushPresetToDevice(
   options: PresetPushOptions = {},
 ): Promise<void> {
   const settle = options.effectChangeSettleMs ?? 400;
-  const paramGap = options.interParamDelayMs ?? 8;
+  // 40ms between param writes. USB captures of real device/editor traffic show
+  // the GP-200 never receives two *different* params closer than ~124ms apart,
+  // and even same-target knob sweeps never drop below ~19ms. Our former 8ms
+  // burst is a cadence the device never sees in the wild and it swallows it
+  // (the dropped first-param-of-block was the #80 symptom). 40ms sits clear of
+  // the device's processing window while keeping a full load reasonably fast.
+  const paramGap = options.interParamDelayMs ?? 40;
   const blockGap = options.interBlockDelayMs ?? 10;
   const sleep = options.sleep ?? defaultSleep;
 

--- a/tests/unit/devicePush.test.ts
+++ b/tests/unit/devicePush.test.ts
@@ -86,6 +86,22 @@ describe('pushPresetToDevice', () => {
     expect(block0Params[block0Params.length - 1]).toBe('param:0:0:5');
   });
 
+  it('spaces consecutive param writes by 40ms so the device does not drop the burst (#80)', async () => {
+    const { events, sender, sleep } = makeRecorder();
+    await pushPresetToDevice(twoBlockPreset(), sender, { sleep });
+
+    // Real USB captures show the GP-200 never receives two *different* params
+    // closer than ~124ms, and even same-target knob sweeps never go below ~19ms.
+    // Our former 8ms burst is a pattern the device never sees in the wild — it
+    // swallows it. Each param write is now followed by a 40ms gap by default,
+    // comfortably above the device's processing window (#80).
+    events.forEach((e, i) => {
+      if (e.startsWith('param:')) {
+        expect(events[i + 1]).toBe('sleep:40');
+      }
+    });
+  });
+
   it('sends the author last, after both param passes', async () => {
     const { events, sender, sleep } = makeRecorder();
     await pushPresetToDevice(twoBlockPreset(), sender, { sleep });


### PR DESCRIPTION
## Problem (#80)
On preset load, the **first parameter of every effect** landed as `0` on the device (e.g. amp gain), even though the byte-identical message lands fine when sent alone (manual knob edit). PR #84 (display-value field) and PR #85 (re-send param 0) helped but the reporter still saw zeroes.

## Evidence from real USB captures
Decoded the local `caps/` corpus (124 captures → 88 with data) with `analyze-sysex.py` and measured inter-param timing across **222 real param→param transitions**:

| Metric | Real device/editor | Our editor (load) |
|---|---|---|
| Median gap between param writes | **259 ms** | 8 ms |
| Min gap (same-target sweep) | 19 ms | 8 ms |
| Fast sends to *different* params (<50 ms) | **0 — never happens** | full block at once |

The device **never** receives a rapid burst of *different* params in real-world use. Our load sent params 0..14 of a block ~8 ms apart — a cadence that exists in no capture — and the device swallows the first one.

## Fix
Raise `interParamDelayMs` default **8 → 40 ms** — clear of the device's processing window, while keeping a full load reasonably fast. Complements the param-0 re-send (#85) and the 400 ms effect-change settle (both kept).

## Tests
- New unit test asserts every param write is followed by a 40 ms gap.
- Full suite green (756 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)