### PR TITLE
feat(midi): non-blocking push progress + cancel in-flight push on reload

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "»{name}« auf Slot {slot} speichern?",
     "savingToSlot": "Speichere auf {slot}…",
     "confirmSave": "Speichern",
-    "cancelSave": "Abbrechen"
+    "cancelSave": "Abbrechen",
+    "pushing": "Sende an Gerät…",
+    "pushDone": "An Gerät gesendet"
   },
   "help": {
     "title": "Hilfe",

--- a/messages/en.json
+++ b/messages/en.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "Save »{name}« to slot {slot}?",
     "savingToSlot": "Saving to {slot}…",
     "confirmSave": "Save",
-    "cancelSave": "Cancel"
+    "cancelSave": "Cancel",
+    "pushing": "Sending to device…",
+    "pushDone": "Sent to device"
   },
   "help": {
     "title": "Help",

--- a/messages/es.json
+++ b/messages/es.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "¿Guardar »{name}« en el slot {slot}?",
     "savingToSlot": "Guardando en {slot}…",
     "confirmSave": "Guardar",
-    "cancelSave": "Cancelar"
+    "cancelSave": "Cancelar",
+    "pushing": "Enviando al dispositivo…",
+    "pushDone": "Enviado al dispositivo"
   },
   "help": {
     "title": "Ayuda",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "Enregistrer « {name} » dans le slot {slot} ?",
     "savingToSlot": "Enregistrement dans {slot}…",
     "confirmSave": "Enregistrer",
-    "cancelSave": "Annuler"
+    "cancelSave": "Annuler",
+    "pushing": "Envoi vers l'appareil…",
+    "pushDone": "Envoyé à l'appareil"
   },
   "help": {
     "title": "Aide",

--- a/messages/it.json
+++ b/messages/it.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "Salvare »{name}« sullo slot {slot}?",
     "savingToSlot": "Salvataggio su {slot}…",
     "confirmSave": "Salva",
-    "cancelSave": "Annulla"
+    "cancelSave": "Annulla",
+    "pushing": "Invio al dispositivo…",
+    "pushDone": "Inviato al dispositivo"
   },
   "help": {
     "title": "Aiuto",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "Salvar »{name}« no slot {slot}?",
     "savingToSlot": "Salvando em {slot}…",
     "confirmSave": "Salvar",
-    "cancelSave": "Cancelar"
+    "cancelSave": "Cancelar",
+    "pushing": "Enviando ao dispositivo…",
+    "pushDone": "Enviado ao dispositivo"
   },
   "help": {
     "title": "Ajuda",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -343,7 +343,9 @@
     "confirmSaveToSlot": "Guardar »{name}« no slot {slot}?",
     "savingToSlot": "A guardar em {slot}…",
     "confirmSave": "Guardar",
-    "cancelSave": "Cancelar"
+    "cancelSave": "Cancelar",
+    "pushing": "Enviando ao dispositivo…",
+    "pushDone": "Enviado ao dispositivo"
   },
   "help": {
     "title": "Ajuda",

--- a/src/app/[locale]/editor/page.tsx
+++ b/src/app/[locale]/editor/page.tsx
@@ -25,7 +25,7 @@ import { AddToPlaylistDialog } from '@/components/AddToPlaylistDialog';
 import { GuitarRating } from '@/components/GuitarRating';
 import { SysExCodec } from '@/core/SysExCodec';
 import { convertHLX } from '@/core/HLXConverter';
-import { pushPresetToDevice } from '@/core/devicePush';
+import { pushPresetToDevice, type PushProgress } from '@/core/devicePush';
 import type { GP200Preset } from '@/core/types';
 
 const PRESET_STYLES = [
@@ -64,6 +64,11 @@ export default function EditorPage() {
   const [showPresetInfo, setShowPresetInfo] = useState(true);
   const [showController, setShowController] = useState(false);
   const pedalGridRef = useRef<HTMLDivElement>(null);
+  // Live-push to device: progress for the UI + an abort handle so loading a new
+  // preset cancels the in-flight push (a full push takes ~15s — two overlapping
+  // pushes would interleave their param writes and corrupt the device).
+  const [pushProgress, setPushProgress] = useState<PushProgress | null>(null);
+  const pushAbortRef = useRef<AbortController | null>(null);
   // Track source preset when loaded from gallery (for update vs save-as-new)
   const [sourcePreset, setSourcePreset] = useState<{ id: string; username: string; author: string; style: string; description: string } | null>(null);
   const [importedFromHLX, setImportedFromHLX] = useState(false);
@@ -209,13 +214,46 @@ export default function EditorPage() {
   // is used as the device block, NOT eff.slotIndex (routing position).
   const sendPresetToDevice = useCallback(async (decoded: GP200Preset) => {
     if (midiDevice.status !== 'connected') return;
-    await pushPresetToDevice(decoded, {
-      sendEffectChange: midiDevice.sendEffectChange,
-      sendParamChange: midiDevice.sendParamChange,
-      sendToggle: midiDevice.sendToggle,
-      sendAuthor: midiDevice.sendAuthor,
-    });
+    // Cancel any push still in flight so two loads never interleave on the device.
+    pushAbortRef.current?.abort();
+    const ac = new AbortController();
+    pushAbortRef.current = ac;
+    setPushProgress({ completed: 0, total: decoded.effects.length * 2, phase: 'configuring' });
+    try {
+      await pushPresetToDevice(
+        decoded,
+        {
+          sendEffectChange: midiDevice.sendEffectChange,
+          sendParamChange: midiDevice.sendParamChange,
+          sendToggle: midiDevice.sendToggle,
+          sendAuthor: midiDevice.sendAuthor,
+        },
+        {
+          signal: ac.signal,
+          // Ignore late callbacks from a push that has since been superseded.
+          onProgress: (p: PushProgress) => { if (!ac.signal.aborted) setPushProgress(p); },
+        },
+      );
+    } finally {
+      if (pushAbortRef.current === ac) pushAbortRef.current = null;
+    }
   }, [midiDevice]);
+
+  // Clear the "done" indicator a moment after a push finishes.
+  useEffect(() => {
+    if (pushProgress?.phase !== 'done') return;
+    const id = setTimeout(() => setPushProgress(null), 2000);
+    return () => clearTimeout(id);
+  }, [pushProgress]);
+
+  // Abort an in-flight push (and hide the indicator) the moment the device drops.
+  useEffect(() => {
+    if (midiDevice.status !== 'connected') {
+      pushAbortRef.current?.abort();
+      pushAbortRef.current = null;
+      setPushProgress(null);
+    }
+  }, [midiDevice.status]);
 
   const handleFile = useCallback((buffer: Uint8Array, filename: string) => {
     try {
@@ -597,6 +635,7 @@ export default function EditorPage() {
           onPushRequest={() => handleOpenBrowser('push')}
           onSaveToActiveSlot={midiDevice.status === 'connected' ? handleSaveToActiveSlot : undefined}
           onPresetNameChange={preset ? (name: string) => setPatchName(name) : undefined}
+          pushProgress={pushProgress}
         />
       </div>
 

--- a/src/components/DeviceStatusBar.tsx
+++ b/src/components/DeviceStatusBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useTranslations } from 'next-intl';
 import type { UseMidiDeviceReturn } from '@/hooks/useMidiDevice';
+import type { PushProgress } from '@/core/devicePush';
 import { SysExCodec } from '@/core/SysExCodec';
 // Firmware compat uses versionAccepted from handshake, not string matching
 import { useState, useEffect } from 'react';
@@ -13,6 +14,8 @@ interface DeviceStatusBarProps {
   onPushRequest: () => void;
   onSaveToActiveSlot?: () => Promise<void>;
   onPresetNameChange?: (name: string) => void;
+  /** Live-push progress while a freshly loaded preset is sent to the device. */
+  pushProgress?: PushProgress | null;
 }
 
 export function DeviceStatusBar({
@@ -23,6 +26,7 @@ export function DeviceStatusBar({
   onPushRequest,
   onSaveToActiveSlot,
   onPresetNameChange,
+  pushProgress,
 }: DeviceStatusBarProps) {
   const t = useTranslations('device');
   const { status, errorMessage, currentSlot, connect, disconnect } = midiDevice;
@@ -139,6 +143,38 @@ export function DeviceStatusBar({
         <span className="font-mono-display" style={{ color: 'var(--accent-red)', fontSize: '0.8em' }}>
           {errorMessage ?? t('error')}
         </span>
+      )}
+
+      {/* Live-push progress (non-blocking — user can keep editing) */}
+      {pushProgress && (
+        <div
+          className="flex items-center gap-2 font-mono-display"
+          style={{ fontSize: '0.75em', color: pushProgress.phase === 'done' ? 'var(--accent-green)' : 'var(--accent-amber)' }}
+          data-testid="push-progress"
+          role="status"
+          aria-live="polite"
+        >
+          {pushProgress.phase === 'done' ? (
+            <span>✓ {t('pushDone')}</span>
+          ) : (
+            <>
+              <span>{t('pushing')}</span>
+              <span
+                aria-hidden
+                style={{ position: 'relative', width: 56, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.1)', overflow: 'hidden' }}
+              >
+                <span
+                  style={{
+                    position: 'absolute', insetBlock: 0, left: 0,
+                    width: `${pushProgress.total > 0 ? Math.round((pushProgress.completed / pushProgress.total) * 100) : 0}%`,
+                    background: 'var(--accent-amber)', transition: 'width 0.2s linear',
+                  }}
+                />
+              </span>
+              <span style={{ color: 'var(--text-muted)' }}>{pushProgress.completed}/{pushProgress.total}</span>
+            </>
+          )}
+        </div>
       )}
 
       {/* Actions */}

--- a/src/core/devicePush.ts
+++ b/src/core/devicePush.ts
@@ -11,6 +11,15 @@ export interface PresetPushSender {
   sendAuthor: (author: string) => void;
 }
 
+export interface PushProgress {
+  /** completed work units — one per block per pass */
+  completed: number;
+  /** total work units = blocks × 2 passes */
+  total: number;
+  /** 'configuring' = pass 1, 'finalizing' = pass 2, 'done' = fully sent */
+  phase: 'configuring' | 'finalizing' | 'done';
+}
+
 export interface PresetPushOptions {
   /** ms to wait after an effect change before writing that block's params */
   effectChangeSettleMs?: number;
@@ -20,6 +29,14 @@ export interface PresetPushOptions {
   interBlockDelayMs?: number;
   /** Injectable sleep — overridden in tests to record timing without waiting. */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Aborts the push mid-flight. A full push takes ~15s; if the user loads
+   * another preset meanwhile the caller aborts the in-flight one so two pushes
+   * never interleave their param writes on the device.
+   */
+  signal?: AbortSignal;
+  /** Progress callback, fired after each block and once more when done. */
+  onProgress?: (progress: PushProgress) => void;
 }
 
 const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -58,6 +75,10 @@ export async function pushPresetToDevice(
   const paramGap = options.interParamDelayMs ?? 40;
   const blockGap = options.interBlockDelayMs ?? 10;
   const sleep = options.sleep ?? defaultSleep;
+  const { signal, onProgress } = options;
+
+  const total = decoded.effects.length * 2; // pass 1 + pass 2
+  let completed = 0;
 
   const sendBlockParams = async (i: number, eff: GP200Preset['effects'][number]) => {
     for (let p = 0; p < eff.params.length; p++) {
@@ -79,19 +100,28 @@ export async function pushPresetToDevice(
 
   // Pass 1: per block — effect type, settle, params, toggle.
   for (let i = 0; i < decoded.effects.length; i++) {
+    if (signal?.aborted) return;
     const eff = decoded.effects[i];
     sender.sendEffectChange(i, eff.effectId);
     await sleep(settle);
+    if (signal?.aborted) return;
     await sendBlockParams(i, eff);
     sender.sendToggle(i, eff.enabled);
     await sleep(blockGap);
+    completed += 1;
+    onProgress?.({ completed, total, phase: 'configuring' });
   }
 
   // Pass 2: every algorithm is loaded now — re-send all params so writes that
   // raced a still-loading block in pass 1 are applied (#80).
   for (let i = 0; i < decoded.effects.length; i++) {
+    if (signal?.aborted) return;
     await sendBlockParams(i, decoded.effects[i]);
+    completed += 1;
+    onProgress?.({ completed, total, phase: 'finalizing' });
   }
 
+  if (signal?.aborted) return;
   if (decoded.author) sender.sendAuthor(decoded.author);
+  onProgress?.({ completed: total, total, phase: 'done' });
 }

--- a/tests/unit/DeviceStatusBar.test.tsx
+++ b/tests/unit/DeviceStatusBar.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DeviceStatusBar } from '@/components/DeviceStatusBar';
+import type { UseMidiDeviceReturn } from '@/hooks/useMidiDevice';
+import type { PushProgress } from '@/core/devicePush';
+import { NextIntlClientProvider } from 'next-intl';
+import messages from '@/../messages/en.json';
+
+// Minimal connected device — only the fields DeviceStatusBar reads on the
+// 'connected' render path. Cast keeps the test from enumerating the whole hook.
+function connectedDevice(): UseMidiDeviceReturn {
+  return {
+    status: 'connected',
+    errorMessage: null,
+    currentSlot: 0,
+    presetNames: Array(256).fill(''),
+    namesLoadProgress: 256,
+    deviceInfo: null,
+    handshakeStep: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as UseMidiDeviceReturn;
+}
+
+function wrap(pushProgress: PushProgress | null) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <DeviceStatusBar
+        midiDevice={connectedDevice()}
+        currentPresetName="Test"
+        hasPreset
+        onPullRequest={() => {}}
+        onPushRequest={() => {}}
+        pushProgress={pushProgress}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('DeviceStatusBar push indicator', () => {
+  it('shows nothing when no push is in flight', () => {
+    wrap(null);
+    expect(screen.queryByTestId('push-progress')).toBeNull();
+  });
+
+  it('shows the sending label and block count while configuring', () => {
+    wrap({ completed: 3, total: 22, phase: 'configuring' });
+    const el = screen.getByTestId('push-progress');
+    expect(el.textContent).toContain('Sending to device');
+    expect(el.textContent).toContain('3/22');
+  });
+
+  it('shows the done label when the push finishes', () => {
+    wrap({ completed: 22, total: 22, phase: 'done' });
+    const el = screen.getByTestId('push-progress');
+    expect(el.textContent).toContain('Sent to device');
+  });
+});

--- a/tests/unit/devicePush.test.ts
+++ b/tests/unit/devicePush.test.ts
@@ -108,4 +108,40 @@ describe('pushPresetToDevice', () => {
     const nonSleep = events.filter((e) => !e.startsWith('sleep:'));
     expect(nonSleep[nonSleep.length - 1]).toBe('author:Tester');
   });
+
+  it('stops sending once the abort signal fires (no overlapping pushes)', async () => {
+    const { events, sender } = makeRecorder();
+    const ac = new AbortController();
+    // Abort during the very first effect-change settle.
+    let sleeps = 0;
+    const sleep = async () => {
+      sleeps += 1;
+      if (sleeps === 1) ac.abort();
+    };
+    await pushPresetToDevice(twoBlockPreset(), sender, { sleep, signal: ac.signal });
+
+    // Block 0's effect-change was sent before the abort; nothing after it should be.
+    expect(events).toContain('fx:0:17');
+    expect(events.some((e) => e.startsWith('param:'))).toBe(false);
+    expect(events.some((e) => e.startsWith('toggle:'))).toBe(false);
+    expect(events.some((e) => e.startsWith('author:'))).toBe(false);
+    expect(events.some((e) => e === 'fx:1:34')).toBe(false);
+  });
+
+  it('reports progress per block across both passes, ending with a done phase', async () => {
+    const { sender, sleep } = makeRecorder();
+    const updates: string[] = [];
+    await pushPresetToDevice(twoBlockPreset(), sender, {
+      sleep,
+      onProgress: (p) => updates.push(`${p.phase}:${p.completed}/${p.total}`),
+    });
+    // 2 blocks × 2 passes = 4 work units; pass 1 = configuring, pass 2 = finalizing.
+    expect(updates).toEqual([
+      'configuring:1/4',
+      'configuring:2/4',
+      'finalizing:3/4',
+      'finalizing:4/4',
+      'done:4/4',
+    ]);
+  });
 });


### PR DESCRIPTION
## Why
After #86 the live preset→device push takes ~15 s (40 ms param spacing). It ran **silently** — no UI feedback — and had **no guard against overlap**. At that duration two problems became real:
1. The user can't tell a sync is running or when it's done.
2. Loading a second preset mid-push made two pushes interleave their param writes on the device → corruption.

## What
**Robustness (core, test-first):**
- `pushPresetToDevice` accepts an `AbortSignal` (checked before each block and each pass) and an `onProgress` callback (fired per block + a final `done`).
- Unit tests: aborting stops all further sends; progress reports `configuring → finalizing → done` with correct counts.

**Editor wiring:**
- Aborts any in-flight push before starting a new one, and on device disconnect — two pushes can never overlap.

**UI (`DeviceStatusBar`):**
- Non-blocking indicator: label + progress bar + block count, then a brief "✓ sent". `role="status"` / `aria-live="polite"` for screen readers. The user keeps editing the whole time (no modal).
- i18n: `device.pushing` / `device.pushDone` across all 7 locales.

## Tests
- **761 passed** (+5: 2 core abort/progress, 3 indicator render). Typecheck, lint, production build all green.

## Note
The indicator's behavior during a real hardware push wasn't verified on-device (no GP-200 on this machine); the core abort/progress logic is unit-tested and the render is type-checked + render-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)