### PR TITLE
chore: gitignore scripts pcaps + refresh capture catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,12 +50,13 @@ next-env.d.ts
 
 # Third-party/external files
 /others
-caps/
 
 # Large binary/data directories
 official/
 others/
 caps/
+scripts/*.pcap
+__pycache__/
 screens/
 .playwright-mcp/
 planung/

--- a/docs/capture-catalog.md
+++ b/docs/capture-catalog.md
@@ -4,9 +4,9 @@ Auto-generierter Katalog aller lokalen USB-MIDI Captures. Erzeugt mit `python sc
 
 > ⚠️ Die `.pcap`-Rohdaten sind **nicht** im Git-Repo (`scripts/*.pcap` untracked, `caps/` in `.gitignore`). Dieser Katalog ist die durchsuchbare Übersicht; die Binärdaten liegen nur lokal / im Backup.
 
-- **Captures:** 130
-- **Gesamtgröße:** 619.7 MB
-- **SysEx-Nachrichten gesamt:** 32913
+- **Captures:** 88
+- **Gesamtgröße:** 488.8 MB
+- **SysEx-Nachrichten gesamt:** 32675
 
 Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 
@@ -14,49 +14,13 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 
 | Datei | Größe | Msgs | Kategorie |
 |-------|-------|-----:|-----------|
-| `gp200-capture-effect-change.pcap` | 18 KB | 24 | IR/NAM multi-chunk upload (sub=0x1C) ×23; CMD 12 sub 0C ×1 |
-| `gp200-ir-load-user.pcap` | 18 KB | 24 | IR/NAM multi-chunk upload (sub=0x1C) ×23; CMD 12 sub 0C ×1 |
-| `gp200-ir-load-userIR3.pcap` | 19 KB | 29 | Toggle [CAB+]; IR/NAM multi-chunk upload (sub=0x1C) ×23; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×2; CMD 12 sub 08 ×1 |
-| `gp200-ir-load.pcap` | 36 KB | 60 | Toggle [CAB+,PRE+,WAH-]; IR/NAM multi-chunk upload (sub=0x1C) ×46; CMD 12 sub 0C ×4; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 08 ×2 |
-| `gp200-nam-load.pcap` | 34 KB | 51 | Toggle [AMP+]; IR/NAM multi-chunk upload (sub=0x1C) ×45; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×2; CMD 12 sub 08 ×1 |
-| `gp200-nam-load2.pcap` | 34 KB | 50 | IR/NAM multi-chunk upload (sub=0x1C) ×45; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×2; CMD 12 sub 08 ×1 |
-
-## Zeitstempel-Captures (`scripts/`)
-
-### 2026-03-18
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
 | `gp200-capture-20260318-231056.pcap` | 1.9 MB | 20 | Preset-Write → Slot [9] 'American Idiot'; Preset-Change (1×, #[10]); Toggle [EQ+,NR+,PRE-,WAH-]; CMD 12 sub 18 ×7 |
 | `gp200-capture-20260318-232435.pcap` | 2.0 MB | 9 | Preset-Change (4×, #[7, 9, 10, 11]); Toggle [NR+,PRE-,VOL-] |
 | `gp200-capture-20260318-232621.pcap` | 1.5 MB | 10 | Preset-Change (3×, #[9, 10, 11]); Toggle [NR+,PRE-]; CMD 12 sub 18 ×1 |
 | `gp200-capture-20260318-235014.pcap` | 1.4 MB | 40 | Preset-Change (18×, #[0, 1, 2, 3, 4, 5, 6]) |
-| `gp200-capture-20260318-235247.pcap` | 595 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260318-235705.pcap` | 2.7 MB | 69 | IR/NAM multi-chunk upload (sub=0x1C) ×69 |
 | `gp200-capture-20260318-235943.pcap` | 545 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
-
-### 2026-03-19
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
-| `gp200-capture-20260319-003621.pcap` | 486 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-003827.pcap` | 1.1 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-010828.pcap` | 3.3 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-010955.pcap` | 2.7 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-011106.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-011157.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-011229.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-011529.pcap` | 1.1 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-011832.pcap` | 3.6 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-012329.pcap` | 1.5 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-012527.pcap` | 529 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-072019.pcap` | 0 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-072053.pcap` | 227 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-072121.pcap` | 29 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-072144.pcap` | 114 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260319-072206.pcap` | 1.1 MB | 2173 | Preset-Read/State-Dump (257 Presets); CMD 11 sub 1C ×34; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
-| `gp200-capture-20260319-100435.pcap` | 2 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-100523.pcap` | 1 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260319-100548.pcap` | 9 KB | 14 | Preset-Change (1×, #[0]); Toggle [BOOST-,CAB+,DLY+,MOD+,PRE-,WAH-]; CMD 12 sub 18 ×1 |
 | `gp200-capture-20260319-101538.pcap` | 15 KB | 43 | Preset-Change (1×, #[0]); Toggle [AMP+,CAB+,DLY+,PRE-,VOL+,VOL-,WAH-]; CMD 12 sub 18 ×23; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 0C ×2; CMD 12 sub 08 ×2; CMD 12 sub 20 ×1 |
 | `gp200-capture-20260319-101714.pcap` | 49 KB | 213 | Toggle [BOOST+,WAH-]; CMD 12 sub 18 ×203; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 20 ×2; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1 |
@@ -71,25 +35,11 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 | `gp200-capture-20260319-114632.pcap` | 1.2 MB | 2211 | Preset-Read/State-Dump (259 Presets); CMD 11 sub 1C ×60; IR/NAM multi-chunk upload (sub=0x1C) ×54; state-dump chunk (sub=0x4E) ×10; CMD 11 sub 04 ×4; CMD 11 sub 12 ×2; CMD 11 sub 0A ×2; CMD 12 sub 0A ×2 |
 | `gp200-capture-20260319-114725.pcap` | 34.4 MB | 2218 | Preset-Write → Slot [0] 'Pretender 3'; Preset-Read/State-Dump (258 Presets); Preset-Change (1×, #[0]); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,BOOST,CAB,DLY,EQ,MOD,NR,PRE,PRE+,RVB,VOL,WAH,WAH-]; CMD 11 sub 1C ×60; IR/NAM multi-chunk upload (sub=0x1C) ×54; state-dump chunk (sub=0x4E) ×10; CMD 12 sub 18 ×6; CMD 11 sub 04 ×4; CMD 11 sub 12 ×2; CMD 11 sub 0A ×2; CMD 12 sub 0A ×2; CMD 12 sub 08 ×1 |
 | `gp200-capture-20260319-221628.pcap` | 82.6 MB | 6 | Preset-Change (2×, #[0, 4]); Toggle [PRE-,VOL+] |
-| `gp200-capture-20260319-221746.pcap` | 250 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260319-221950.pcap` | 88.8 MB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260319-222343.pcap` | 12 KB | 33 | Preset-Change (8×, #[0, 1, 2, 3, 4, 5, 6, 7]); Toggle [?0D+,CAB+,PRE-,VOL+,WAH+] |
-
-### 2026-03-20
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
 | `gp200-capture-20260320-143029.pcap` | 13 KB | 14 | Preset-Change (1×, #[1]); Toggle [BOOST-,NR+,PRE-]; CMD 12 sub 20 ×1; CMD 12 sub 38 ×1; CMD 12 sub 18 ×1 |
 | `gp200-capture-20260320-151140.pcap` | 1.1 MB | 2175 | Preset-Read/State-Dump (257 Presets); CMD 11 sub 1C ×32; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
-| `gp200-capture-20260320-152209.pcap` | 6 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260320-152215.pcap` | 48 KB | 77 | Preset-Read/State-Dump (9 Presets); Preset-Change (2×, #[2]); Toggle [AMP,BOOST,NR+,PRE,PRE-,VOL+,WAH] |
-
-### 2026-03-23
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
 | `gp200-capture-20260323-121456.pcap` | 6.9 MB | 2 | Toggle [EQ+,NR+] |
-| `gp200-capture-20260323-121520.pcap` | 6.9 MB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260323-121559.pcap` | 11 KB | 23 | CMD 12 sub 20 ×11; param/effect-change or controller assignment (sub=0x14, 54B raw) ×11 |
 | `gp200-capture-20260323-121732.pcap` | 9 KB | 11 | Preset-Change (4×, #[1, 15]); Toggle [NR+,PRE-]; CMD 12 sub 18 ×1 |
 | `gp200-capture-20260323-121825.pcap` | 10 KB | 17 | Preset-Change (4×, #[0, 1]); Toggle [NR+,PRE-,WAH-]; CMD 12 sub 18 ×1 |
@@ -98,7 +48,6 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 | `gp200-capture-20260323-122704.pcap` | 22.3 MB | 34 | param/effect-change or controller assignment (sub=0x14, 54B raw) ×33 |
 | `gp200-capture-20260323-122940.pcap` | 10.2 MB | 2 | param/effect-change or controller assignment (sub=0x14, 54B raw) ×1 |
 | `gp200-capture-20260323-124534.pcap` | 71 KB | 124 | Preset-Read/State-Dump (14 Presets); Toggle [AMP,BOOST,BOOST+,CAB,NR,NR+,PRE,PRE-,VOL+,WAH] |
-| `gp200-capture-20260323-124718.pcap` | 7.3 MB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260323-124730.pcap` | 10 KB | 24 | Toggle [NR+,PRE-,VOL+] |
 | `gp200-capture-20260323-130830.pcap` | 30 KB | 45 | Preset-Read/State-Dump (5 Presets); Toggle [BOOST+,BOOST-,NR+,PRE] |
 | `gp200-capture-20260323-131350.pcap` | 7 KB | 4 | Toggle [BOOST+,NR+,PRE-,WAH-] |
@@ -109,7 +58,6 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 | `gp200-capture-20260323-134828.pcap` | 45 KB | 10 | CMD 12 sub 0C ×4; CMD 12 sub 08 ×4; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2 |
 | `gp200-capture-20260323-140802.pcap` | 76 KB | 415 | Toggle [EQ-,NR+,PRE-,WAH-] |
 | `gp200-capture-20260323-141104.pcap` | 19 KB | 75 | Toggle [PRE-,WAH-] |
-| `gp200-capture-20260323-141239.pcap` | 9 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260323-141331.pcap` | 145 KB | 651 | Preset-Read/State-Dump (8 Presets); Toggle [AMP,BOOST,EQ-,PRE,PRE-,WAH,WAH-]; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 1C ×4; IR/NAM multi-chunk upload (sub=0x1C) ×3; CMD 11 sub 04 ×2; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
 | `gp200-capture-20260323-142122.pcap` | 8 KB | 14 | fx_state_resp×14 |
 | `gp200-capture-20260323-142750.pcap` | 41 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
@@ -122,10 +70,8 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 | `gp200-capture-20260323-174918.pcap` | 9 KB | 9 | Toggle [AMP+]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 0C ×3; CMD 12 sub 08 ×2 |
 | `gp200-capture-20260323-175101.pcap` | 8.5 MB | 2267 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0B+,?0C,?0C+,?0D,?0E,?0F,AMP,AMP+,BOOST,CAB,DLY,EQ,MOD,NR,PRE,PRE+,RVB,VOL,VOL+,WAH,WAH-]; CMD 11 sub 04 ×45; CMD 11 sub 1C ×30; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 12 ×23; CMD 12 sub 12 ×22; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; param/effect-change or controller assignment (sub=0x14, 54B raw) ×2; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1; CMD 12 sub 04 ×1 |
 | `gp200-capture-20260323-180104.pcap` | 2.3 MB | 54 | Toggle [AMP+]; IR/NAM multi-chunk upload (sub=0x1C) ×45; param/effect-change or controller assignment (sub=0x14, 54B raw) ×3; CMD 12 sub 0C ×2; CMD 12 sub 08 ×2 |
-| `gp200-capture-20260323-182011.pcap` | 61 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260323-182027.pcap` | 317 KB | 4 | CMD 11 sub 04 ×2; CMD 11 sub 12 ×1; CMD 12 sub 12 ×1 |
 | `gp200-capture-20260323-183245.pcap` | 30 KB | 23 | IR/NAM multi-chunk upload (sub=0x1C) ×23 |
-| `gp200-capture-20260323-200348.pcap` | 7 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260323-200453.pcap` | 7 KB | 3 | Preset-Change (1×, #[0]); Toggle [PRE-,RVB+] |
 | `gp200-capture-20260323-200517.pcap` | 22 KB | 80 | Toggle [PRE-]; param/effect-change or controller assignment (sub=0x14, 54B raw) ×25; CMD 12 sub 18 ×9; CMD 12 sub 08 ×1 |
 | `gp200-capture-20260323-201458.pcap` | 33 KB | 170 | fx_state_resp×170 |
@@ -143,42 +89,17 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 | `gp200-capture-20260323-211407.pcap` | 1.2 MB | 2287 | Preset-Read/State-Dump (266 Presets); CMD 11 sub 1C ×64; IR/NAM multi-chunk upload (sub=0x1C) ×39; CMD 12 sub 18 ×21; CMD 11 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×4; CMD 11 sub 0A ×2; CMD 12 sub 0A ×2; CMD 11 sub 12 ×1 |
 | `gp200-capture-20260323-211645.pcap` | 9 KB | 10 | Toggle [PRE-]; CMD 12 sub 18 ×4; CMD 12 sub 08 ×1 |
 | `gp200-capture-20260323-212146.pcap` | 7 KB | 3 | Toggle [PRE-]; CMD 12 sub 18 ×1; CMD 12 sub 08 ×1 |
-
-### 2026-03-24
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
 | `gp200-capture-20260324-084047.pcap` | 1.6 MB | 2169 | Preset-Read/State-Dump (257 Presets); CMD 11 sub 1C ×30; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×21; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
 | `gp200-capture-20260324-084156.pcap` | 1.1 MB | 2172 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,BOOST,CAB,DLY,EQ,EQ+,MOD,NR,PRE,PRE-,RVB,VOL,WAH,WAH-]; CMD 11 sub 1C ×31; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×3; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
 | `gp200-capture-20260324-085205.pcap` | 197 KB | 1073 | Toggle [?0B+,?0C+,?0D+,?0E+,?0F+,AMP+,BOOST+,CAB+,DLY+,EQ+,MOD+,NR+,PRE+,PRE-,RVB+,VOL+,WAH+,WAH-] |
 | `gp200-capture-20260324-142215.pcap` | 1.5 MB | 1328 | Preset-Read/State-Dump (166 Presets) |
 | `gp200-capture-20260324-142234.pcap` | 6.7 MB | 2179 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,BOOST,CAB,DLY,EQ,EQ+,EQ-,MOD,NR,PRE,RVB,RVB+,VOL,WAH,WAH-]; CMD 11 sub 1C ×31; IR/NAM multi-chunk upload (sub=0x1C) ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; CMD 11 sub 04 ×4; CMD 11 sub 12 ×2; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
 | `gp200-capture-20260324-142321.pcap` | 1.2 MB | 2253 | Preset-Read/State-Dump (257 Presets); Toggle [?0B,?0C,?0D,?0E,?0F,AMP,AMP+,BOOST,CAB,CAB+,CAB-,DLY,EQ,MOD,NR,PRE,RVB,VOL,WAH,WAH-]; IR/NAM multi-chunk upload (sub=0x1C) ×98; CMD 11 sub 1C ×30; CMD 11 sub 18 ×20; CMD 12 sub 18 ×20; state-dump chunk (sub=0x4E) ×5; param/effect-change or controller assignment (sub=0x14, 54B raw) ×4; CMD 11 sub 04 ×3; CMD 12 sub 0C ×2; CMD 12 sub 08 ×2; CMD 11 sub 12 ×1; CMD 11 sub 0A ×1; CMD 12 sub 0A ×1 |
-| `gp200-capture-20260324-153246.pcap` | 4 KB | 0 | leer / kein GP-200 SysEx |
-
-### 2026-04-12
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
-| `gp200-capture-20260412-143324.pcap` | 1.2 MB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260412-143406.pcap` | 990 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260412-143450.pcap` | 680 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260412-143509.pcap` | 70 KB | 329 | CMD 12 sub 18 ×329 |
-| `gp200-capture-20260412-143526.pcap` | 305 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260412-143550.pcap` | 1.6 MB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260412-143552.pcap` | 223 KB | 1093 | Toggle [CAB+,CAB-]; CMD 12 sub 18 ×1086; param/effect-change or controller assignment (sub=0x14, 54B raw) ×1; CMD 12 sub 0C ×1; CMD 12 sub 08 ×1 |
-| `gp200-capture-20260412-143744.pcap` | 665 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260412-143745.pcap` | 12 KB | 11 | Preset-Write → Slot [9] 'American Idiot'; Preset-Change (1×, #[1]); Toggle [NR+,PRE-,WAH-] |
-| `gp200-capture-20260412-143836.pcap` | 988 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260412-150422.pcap` | 533 KB | 1015 | Preset-Read/State-Dump (117 Presets); CMD 12 sub 18 ×74 |
-| `gp200-capture-20260412-150544.pcap` | 628 KB | 0 | leer / kein GP-200 SysEx |
-| `gp200-capture-20260412-150741.pcap` | 731 KB | 0 | leer / kein GP-200 SysEx |
 | `gp200-capture-20260412-150809.pcap` | 14 KB | 51 | CMD 12 sub 18 ×49 |
-
-### 2026-05-18
-
-| Datei | Größe | Msgs | Kategorie |
-|-------|-------|-----:|-----------|
 | `gp200-capture-20260518-075745.pcap` | 10 KB | 21 | CMD 12 sub 20 ×10; param/effect-change or controller assignment (sub=0x14, 54B raw) ×10 |
 | `gp200-capture-20260518-075856.pcap` | 14 KB | 41 | Preset-Change (1×, #[1]); Toggle [PRE-,RVB+,WAH-]; CMD 12 sub 20 ×18; param/effect-change or controller assignment (sub=0x14, 54B raw) ×18; CMD 12 sub 18 ×1 |
 
@@ -187,14 +108,14 @@ Analyse einer einzelnen Datei: `python scripts/analyze-sysex.py <capture.pcap>`
 | Sub-Command | Hinweis | Vorkommen | Richtung | Payload-Längen | # Captures |
 |-------------|---------|----------:|----------|----------------|-----------:|
 | `cmd12_sub18` | — | 3186 | D+H | 52 | 43 |
-| `cmd12_sub1C` | IR/NAM multi-chunk upload (sub=0x1C) | 975 | D+H | 60,200,340,370 | 26 |
+| `cmd12_sub1C` | IR/NAM multi-chunk upload (sub=0x1C) | 770 | D+H | 60,200,340,370 | 20 |
 | `cmd11_sub1C` | — | 408 | H | 60 | 12 |
-| `cmd12_sub14` | param/effect-change or controller assignment (sub=0x14, 54B raw) | 324 | D+H | 44 | 31 |
+| `cmd12_sub14` | param/effect-change or controller assignment (sub=0x14, 54B raw) | 315 | D+H | 44 | 27 |
 | `cmd11_sub18` | — | 161 | H | 52 | 8 |
 | `cmd11_sub04` | — | 82 | H | 12 | 13 |
-| `cmd12_sub0C` | — | 80 | D | 28,58 | 24 |
-| `cmd12_sub08` | — | 78 | D | 50,66,80,96,110,112,142 | 31 |
+| `cmd12_sub08` | — | 73 | D | 50,66,80,96,110,112,142 | 27 |
 | `cmd12_sub4E` | state-dump chunk (sub=0x4E) | 70 | D | 216,374 | 12 |
+| `cmd12_sub0C` | — | 68 | D | 28,58 | 18 |
 | `cmd12_sub20` | — | 44 | H | 68 | 7 |
 | `cmd11_sub12` | — | 38 | H | 4 | 13 |
 | `cmd12_sub12` | — | 23 | D+H | 4,5 | 2 |


### PR DESCRIPTION
Repo hygiene from the capture cleanup:

- **`.gitignore`**: add `scripts/*.pcap` and `__pycache__/` (124 captures, ~620 MB, were untracked-but-not-ignored — a stray `git add` from a huge commit), drop the duplicate `caps/` line.
- **`docs/capture-catalog.md`**: regenerated after moving captures into `caps/` and pruning 36 empty ones (124 → 88 with data).

Docs/config only — no app code, no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)