### PR TITLE
fix(prst): recover partial routing order instead of dropping it (#90)

### DIFF
--- a/src/core/PRSTDecoder.ts
+++ b/src/core/PRSTDecoder.ts
@@ -74,11 +74,19 @@ export class PRSTDecoder {
       byBlock.push({ slotIndex, enabled, effectId, params });
     }
 
-    // Re-order the array by playback order (routing bytes). When the
-    // routing is identity (0..10) this is a no-op; when the user had
-    // dragged effects in the Valeton editor, it reflects their chosen
-    // playback sequence. Invalid routing bytes (>10 or duplicates) fall
-    // back to identity order so we never lose a block.
+    // Re-order the array by playback order (routing bytes). Each byte is the
+    // slotIndex that plays at position i. When the routing is identity (0..10)
+    // this is a no-op; when the user reordered the chain it reflects their
+    // chosen sequence.
+    //
+    // Defensive reconstruction: keep every valid, in-range, non-duplicate byte
+    // in file order, then append any slots the routing left out (from
+    // out-of-range or duplicated bytes) in canonical order. The result is
+    // ALWAYS a complete 0..10 permutation — no block is dropped or duplicated.
+    // Previously a single corrupt byte failed the strict all-11 check and
+    // collapsed the WHOLE reorder back to default order, silently losing a
+    // real reordering for atypical files (#90). Recovering the valid portion
+    // preserves as much of the stored order as possible instead.
     const routing: number[] = [];
     const seen = new Set<number>();
     for (let i = 0; i < EFFECT_BLOCK_COUNT; i++) {
@@ -88,10 +96,10 @@ export class PRSTDecoder {
         seen.add(v);
       }
     }
-    const effects: GP200Preset['effects'] =
-      routing.length === EFFECT_BLOCK_COUNT
-        ? routing.map((si) => byBlock[si])
-        : byBlock;
+    for (let si = 0; si < EFFECT_BLOCK_COUNT; si++) {
+      if (!seen.has(si)) routing.push(si);
+    }
+    const effects: GP200Preset['effects'] = routing.map((si) => byBlock[si]);
 
     const rawSend = this.parser.readUint8(OFFSET_FX_SEND);
     const rawReturn = this.parser.readUint8(OFFSET_FX_RETURN);

--- a/tests/unit/PRSTDecoder.test.ts
+++ b/tests/unit/PRSTDecoder.test.ts
@@ -22,6 +22,13 @@ function buildTestBuffer(): Uint8Array {
   return buf;
 }
 
+/** Builds a test buffer with explicit routing-order bytes at 0x94..0x9E */
+function buildTestBufferWithRouting(routing: number[]): Uint8Array {
+  const buf = buildTestBuffer();
+  for (let i = 0; i < 11; i++) buf[0x94 + i] = routing[i] ?? 0;
+  return buf;
+}
+
 /** Builds a buffer with known float32 param values at slot 0 */
 function buildTestBufferWithParams(): Uint8Array {
   const buf = buildTestBuffer();
@@ -141,6 +148,36 @@ describe('PRSTDecoder', () => {
     const decoded = new PRSTDecoder(buf).decode();
     expect(decoded.fxLoopSend).toBe(4);
     expect(decoded.fxLoopReturn).toBe(4);
+  });
+
+  it('keeps a full valid routing permutation intact', () => {
+    const routing = [10, 1, 4, 2, 3, 5, 0, 6, 7, 8, 9];
+    const decoded = new PRSTDecoder(buildTestBufferWithRouting(routing)).decode();
+    expect(decoded.effects.map((e) => e.slotIndex)).toEqual(routing);
+  });
+
+  it('recovers a partial routing order when one byte is corrupt, instead of collapsing to default order (#90)', () => {
+    // A valid reorder [3,1,4,0,2,5,6,7,8,9,10] but position 0 is corrupted to 0xFF.
+    // The old all-or-nothing check discarded the WHOLE reorder on a single bad
+    // byte and fell back to default order — the #90 symptom for atypical files.
+    const routing = [0xff, 1, 4, 0, 2, 5, 6, 7, 8, 9, 10];
+    const decoded = new PRSTDecoder(buildTestBufferWithRouting(routing)).decode();
+    // Valid entries kept in file order; the one omitted slot (3) appended last.
+    // No block dropped or duplicated — a full 0..10 permutation is guaranteed.
+    expect(decoded.effects.map((e) => e.slotIndex)).toEqual([1, 4, 0, 2, 5, 6, 7, 8, 9, 10, 3]);
+  });
+
+  it('recovers partial routing that has a duplicate byte', () => {
+    // Position 10 duplicates slot 9; slot 10 is therefore missing and appended.
+    const routing = [1, 4, 0, 2, 3, 5, 6, 7, 8, 9, 9];
+    const decoded = new PRSTDecoder(buildTestBufferWithRouting(routing)).decode();
+    expect(decoded.effects.map((e) => e.slotIndex)).toEqual([1, 4, 0, 2, 3, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('falls back to default order when the routing region is entirely invalid', () => {
+    const routing = new Array(11).fill(0xff);
+    const decoded = new PRSTDecoder(buildTestBufferWithRouting(routing)).decode();
+    expect(decoded.effects.map((e) => e.slotIndex)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 });
 


### PR DESCRIPTION
Follow-up to #91 for issue #90.

## Why
The first fix corrected the on-the-wire block addressing, but the reporter's reordered preset still pushes as **identity order** (`reorder: [0,1,…,10]` in the live-push log). That means the routing is lost at **decode time**, before the device push runs.

## Root cause
`PRSTDecoder` rebuilt the chain order from the 11 routing bytes with a strict all-or-nothing check: if **any** byte was out of range or duplicated, `routing.length !== 11` and the whole reorder was discarded, collapsing the preset back to default order. A single unexpected byte in the routing region trips it.

## Fix
Reconstruct defensively: keep every valid, in-range, non-duplicate byte in file order, then append any omitted slots in canonical order. Result is **always** a complete `0..10` permutation — no block dropped or duplicated. A corrupt byte now only costs its own position, not the entire ordering.

- Clean permutations: unchanged.
- All-invalid routing: still falls back to default order.

## Tests
Partial-corrupt recovery, duplicate-byte recovery, full-permutation preservation, all-invalid → default fallback. Full local CI green (lint + typecheck + test + build).

## Status
This is a **defensive** hardening — it will fix #90 **if** the reporter's file trips the collapse (leading hypothesis). Awaiting his actual `.prst` to confirm the exact byte pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)