### PR TITLE
fix(seo): consolidate the search index onto real content URLs

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,24 +18,24 @@ Key facts:
 
 ## Editor
 
-- [GP-200 Preset Editor](https://www.preset-forge.com/en/editor): Load .prst files, edit all 11 effect slots, adjust parameters, drag-and-drop reorder the signal chain. Push changes live to the device via USB MIDI. Works on Linux, Windows, macOS.
+- [GP-200 Preset Editor](https://www.preset-forge.com/editor): Load .prst files, edit all 11 effect slots, adjust parameters, drag-and-drop reorder the signal chain. Push changes live to the device via USB MIDI. Works on Linux, Windows, macOS.
 
 ## Help & Documentation
 
-- [Help & FAQ](https://www.preset-forge.com/en/help): Getting started, USB MIDI setup (Linux/Windows/macOS), HX Stomp import guide, playlist and cue point documentation, keyboard shortcuts, and FAQ including Linux support details.
+- [Help & FAQ](https://www.preset-forge.com/help): Getting started, USB MIDI setup (Linux/Windows/macOS), HX Stomp import guide, playlist and cue point documentation, keyboard shortcuts, and FAQ including Linux support details.
 
 ## Community
 
-- [Preset Gallery](https://www.preset-forge.com/en/gallery): Browse, download, and share GP-200 presets. Filter by module type and individual effect across all 305 supported effects.
+- [Preset Gallery](https://www.preset-forge.com/gallery): Browse, download, and share GP-200 presets. Filter by module type and individual effect across all 305 supported effects.
 
 ## Presets by Amp Model
 
 Each real-world amp that community presets are modelled on has its own landing page listing every matching GP-200 preset, with the Valeton model name mapped back to the original gear it emulates.
 
-- [Marshall JCM800 presets](https://www.preset-forge.com/en/amp/marshall-jcm800)
-- [Fender '65 Twin Reverb presets](https://www.preset-forge.com/en/amp/fender-65-twin-reverb)
-- [Mesa/Boogie Dual Rectifier presets](https://www.preset-forge.com/en/amp/mesa-boogie-dual-rectifier-modern-mode)
-- [Roland JC-120 Jazz Chorus presets](https://www.preset-forge.com/en/amp/roland-jc-120-jazz-chorus-solid-state-combo)
+- [Marshall JCM800 presets](https://www.preset-forge.com/amp/marshall-jcm800)
+- [Fender '65 Twin Reverb presets](https://www.preset-forge.com/amp/fender-65-twin-reverb)
+- [Mesa/Boogie Dual Rectifier presets](https://www.preset-forge.com/amp/mesa-boogie-dual-rectifier-modern-mode)
+- [Roland JC-120 Jazz Chorus presets](https://www.preset-forge.com/amp/roland-jc-120-jazz-chorus-solid-state-combo)
 
 ## Technical
 
@@ -43,6 +43,6 @@ Each real-world amp that community presets are modelled on has its own landing p
 
 ## Optional
 
-- [Legal Notice](https://www.preset-forge.com/en/legal): Impressum / legal information.
+- [Legal Notice](https://www.preset-forge.com/legal): Impressum / legal information.
 - [Preset Gallery (German)](https://www.preset-forge.com/de/gallery): German-language gallery.
 - [Help (German)](https://www.preset-forge.com/de/help): German-language help and FAQ.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,9 @@
 User-agent: *
 Allow: /
+
+# API routes return JSON or binary payloads, not pages. The
+# /api/share/<token>/json endpoints used to sit in the sitemap (170 URLs)
+# and were being crawled as if they were documents.
+Disallow: /api/
+
 Sitemap: https://www.preset-forge.com/sitemap.xml

--- a/src/app/[locale]/amp/[slug]/page.tsx
+++ b/src/app/[locale]/amp/[slug]/page.tsx
@@ -7,7 +7,7 @@ import {
   findAmpCategoryBySlug,
   listAmpCategories,
 } from '@/core/ampCategories';
-import { buildAlternates, BASE_URL } from '@/lib/hreflang';
+import { buildAlternates, localeUrl } from '@/lib/hreflang';
 import { serializeJsonLd } from '@/lib/jsonLd';
 import { LOCALES, type Locale } from '@/i18n/locales';
 
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const t = await getTranslations({ locale });
   const title = t('amp.metaTitle', { name: cat.realName });
   const description = t('amp.metaDescription', { name: cat.realName });
-  const canonical = `${BASE_URL}/${locale}/amp/${slug}`;
+  const canonical = localeUrl(locale, `/amp/${slug}`);
 
   // Empty amp pages (no community presets) are noindex'd to avoid being
   // flagged as thin content. Crawl is still allowed so Google reaches the
@@ -78,7 +78,7 @@ function buildCollectionJsonLd(opts: {
   homeLabel: string;
   galleryLabel: string;
 }) {
-  const base = `${BASE_URL}/${opts.locale}`;
+  const base = localeUrl(opts.locale, '/');
   const data = {
     '@context': 'https://schema.org',
     '@graph': [

--- a/src/app/[locale]/changelog/page.tsx
+++ b/src/app/[locale]/changelog/page.tsx
@@ -20,6 +20,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
+    // Release notes are for users who already found us, not for search. Over
+    // 2026-04-30..2026-07-29 this page pulled 180 impressions and 1 click
+    // (CTR 0.56%) by ranking on long-tail queries it cannot answer — enough
+    // volume to drag the site-wide CTR and average position down. `follow`
+    // stays on so the links out of it still pass signal.
+    robots: { index: false, follow: true },
     alternates: buildAlternates('/changelog', locale),
     openGraph: { title, description, url: canonical, type: 'website', siteName: 'Preset Forge' },
     twitter: { card: 'summary', title, description },

--- a/src/app/[locale]/changelog/page.tsx
+++ b/src/app/[locale]/changelog/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { Link } from '@/i18n/routing';
 import { getChangelog } from '@/lib/changelog';
 import { ChangelogItemContent } from '@/components/ChangelogItemContent';
-import { buildAlternates, BASE_URL } from '@/lib/hreflang';
+import { buildAlternates, localeUrl } from '@/lib/hreflang';
 import type { Locale } from '@/i18n/locales';
 
 export const revalidate = 3600;
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = 'Changelog — Preset Forge';
   const description =
     'Every release of the Preset Forge Valeton GP-200 editor. Features, bug fixes, protocol discoveries, SEO improvements.';
-  const canonical = `${BASE_URL}/${locale}/changelog`;
+  const canonical = localeUrl(locale, '/changelog');
   return {
     title,
     description,

--- a/src/app/[locale]/gallery/page.tsx
+++ b/src/app/[locale]/gallery/page.tsx
@@ -4,7 +4,7 @@ import { Link } from '@/i18n/routing';
 import { prisma } from '@/lib/prisma';
 import { GalleryClient } from './GalleryClient';
 import { HelpButton } from '@/components/HelpButton';
-import { buildAlternates, BASE_URL, type Locale } from '@/lib/hreflang';
+import { buildAlternates, localeUrl, BASE_URL, type Locale } from '@/lib/hreflang';
 import { serializeJsonLd } from '@/lib/jsonLd';
 
 // The interactive GalleryClient renders fully client-side — Googlebot sees
@@ -79,7 +79,7 @@ export default async function GalleryPage({ params }: Props) {
     itemListElement: recent.map((p, i) => ({
       '@type': 'ListItem',
       position: i + 1,
-      url: `${BASE_URL}/${locale}/share/${p.shareToken}`,
+      url: localeUrl(locale as Locale, `/share/${p.shareToken}`),
       name: p.name,
     })),
   });

--- a/src/app/[locale]/guides/[slug]/page.tsx
+++ b/src/app/[locale]/guides/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { Link } from '@/i18n/routing';
-import { BASE_URL, type Locale } from '@/lib/hreflang';
+import { BASE_URL, localeUrl, DEFAULT_LOCALE, type Locale } from '@/lib/hreflang';
 import { serializeJsonLd } from '@/lib/jsonLd';
 import { getGuide, guideLocales, allGuideParams } from '@/content/guides';
 
@@ -18,13 +18,14 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: L
   const guide = getGuide(locale, slug);
   if (!guide) return {};
 
-  const canonical = `${BASE_URL}/${locale}/guides/${slug}`;
+  const path = `/guides/${slug}`;
+  const canonical = localeUrl(locale, path);
   // hreflang covers only the locales that actually have this guide, plus
   // x-default → English. Listing all 7 would point alternates at 404s.
   const languages: Record<string, string> = {};
   const locales = guideLocales(slug);
-  for (const l of locales) languages[l] = `${BASE_URL}/${l}/guides/${slug}`;
-  if (locales.includes('en')) languages['x-default'] = `${BASE_URL}/en/guides/${slug}`;
+  for (const l of locales) languages[l] = localeUrl(l, path);
+  if (locales.includes(DEFAULT_LOCALE)) languages['x-default'] = localeUrl(DEFAULT_LOCALE, path);
 
   const title = `${guide.title} | Preset Forge`;
   return {
@@ -50,8 +51,8 @@ export default async function GuidePage({ params }: { params: Promise<{ locale: 
 
   const t = await getTranslations({ locale, namespace: 'guides' });
   const nav = await getTranslations({ locale, namespace: 'nav' });
-  const canonical = `${BASE_URL}/${locale}/guides/${slug}`;
-  const base = `${BASE_URL}/${locale}`;
+  const canonical = localeUrl(locale, `/guides/${slug}`);
+  const base = localeUrl(locale, '/');
 
   // TechArticle + BreadcrumbList. Static, author-controlled content, but still
   // routed through serializeJsonLd per project convention.

--- a/src/app/[locale]/guides/page.tsx
+++ b/src/app/[locale]/guides/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import type { Metadata } from 'next';
 import { Link } from '@/i18n/routing';
-import { buildAlternates, BASE_URL, type Locale } from '@/lib/hreflang';
+import { buildAlternates, localeUrl, BASE_URL, type Locale } from '@/lib/hreflang';
 import { listGuidesForIndex } from '@/content/guides';
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     openGraph: {
       title,
       description,
-      url: `${BASE_URL}/${locale}/guides`,
+      url: localeUrl(locale as Locale, '/guides'),
       type: 'website',
       siteName: 'Preset Forge',
       images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630 }],

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,7 +9,7 @@ import '../globals.css'; // globals.css stays in src/app/, so relative path goes
 import { Footer } from '@/components/Footer';
 import { Navbar } from '@/components/Navbar';
 import { ClientProviders } from './ClientProviders';
-import { buildAlternates, BASE_URL, type Locale } from '@/lib/hreflang';
+import { buildAlternates, localeUrl, BASE_URL, type Locale } from '@/lib/hreflang';
 import { serializeJsonLd } from '@/lib/jsonLd';
 
 // Fonts are self-hosted at build time — no runtime request to fonts.googleapis.com,
@@ -57,7 +57,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
       description: 'GP-200 preset editor that runs on Linux, Mac, and Windows. Import HX Stomp .hlx presets, build timed setlists with cue points for live gigs, browse 305 effects in the gallery. USB MIDI, offline PWA.',
       siteName: 'Preset Forge',
       type: 'website',
-      url: `${BASE_URL}/${locale}`,
+      url: localeUrl(locale as Locale, '/'),
       images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Preset Forge — GP-200 Preset Editor' }],
     },
     twitter: {

--- a/src/app/[locale]/legal/page.tsx
+++ b/src/app/[locale]/legal/page.tsx
@@ -6,6 +6,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   return {
     title: 'Legal & Privacy — Preset Forge',
+    // Impressum and privacy policy exist for legal compliance, not for
+    // search. 21 impressions and 0 clicks in Q2/2026.
+    robots: { index: false, follow: true },
     alternates: buildAlternates('/legal', locale as Locale),
   };
 }

--- a/src/app/[locale]/share/[token]/page.tsx
+++ b/src/app/[locale]/share/[token]/page.tsx
@@ -13,7 +13,7 @@ import { encodeToJson } from '@/core/PRSTJsonCodec';
 import { SignalChainSection } from './SignalChainSection';
 import { slugifyAmpName } from '@/core/ampCategories';
 import { Link } from '@/i18n/routing';
-import { buildAlternates, BASE_URL } from '@/lib/hreflang';
+import { buildAlternates, localeUrl } from '@/lib/hreflang';
 import { serializeJsonLd } from '@/lib/jsonLd';
 import type { Locale } from '@/i18n/locales';
 
@@ -77,7 +77,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       .filter(Boolean)
       .join(' · ') + ' — Free Valeton GP-200 preset, open in browser editor.';
 
-  const canonical = `${BASE_URL}/${locale}/share/${token}`;
+  const canonical = localeUrl(locale, `/share/${token}`);
 
   return {
     title,
@@ -177,13 +177,13 @@ export default async function SharePage({ params }: Props) {
     description: preset.description ?? `Valeton GP-200 preset by @${preset.user.username}`,
     brand: { '@type': 'Brand', name: brand },
     category: 'Guitar effect preset',
-    url: `${BASE_URL}/${locale}/share/${token}`,
+    url: localeUrl(locale, `/share/${token}`),
     offers: {
       '@type': 'Offer',
       price: '0',
       priceCurrency: 'USD',
       availability: 'https://schema.org/InStock',
-      url: `${BASE_URL}/${locale}/share/${token}`,
+      url: localeUrl(locale, `/share/${token}`),
     },
   };
   if (preset.ratingCount > 0 && preset.ratingAverage > 0) {
@@ -198,7 +198,7 @@ export default async function SharePage({ params }: Props) {
   // Breadcrumb trail Home › Gallery › [Amp] › Preset. The amp rung only
   // appears when we could decode the amp model, and it deep-links to the same
   // /amp/[slug] landing page the visible "More … presets" link points to.
-  const shareBase = `${BASE_URL}/${locale}`;
+  const shareBase = localeUrl(locale, '/');
   const ampRealName = json?.highlights.amp?.realName ?? null;
   const breadcrumbItems: Array<Record<string, unknown>> = [
     { '@type': 'ListItem', position: 1, name: 'Home', item: shareBase },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -27,8 +27,20 @@ const STATIC_PAGES: Array<{
   { path: '/gallery',    changeFrequency: 'daily',   priority: 0.8 },
   { path: '/help',       changeFrequency: 'monthly', priority: 0.6 },
   { path: '/guides',     changeFrequency: 'monthly', priority: 0.6 },
-  { path: '/changelog',  changeFrequency: 'weekly',  priority: 0.5 },
+  // /changelog is deliberately absent — it is noindex (see its
+  // generateMetadata). 2 100 words of release notes pulled 180 impressions
+  // and 1 click over Q2/2026 (CTR 0.56%, the worst on the site) by ranking
+  // for long-tail queries it cannot answer. Advertising it for crawl would
+  // contradict the noindex.
 ];
+
+// The single locale whose share URLs go into the sitemap. The other six
+// variants of a share page carry identical preset data — same name, same
+// amp, same parameter values — with only the chrome translated, so listing
+// all seven made /share 1 190 of 1 712 sitemap URLs (70%) while the amp and
+// guide pages that actually earn non-brand clicks got 9. The localized
+// variants stay live, self-canonical and reachable via hreflang.
+const SHARE_SITEMAP_LOCALE = 'en';
 
 export default async function sitemap(): Promise<SitemapEntry[]> {
   const now = new Date();
@@ -67,14 +79,12 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
       })),
     );
 
-  // Public preset share pages — 6 locale variants + 1 JSON endpoint per preset.
-  // Sitemap.xml has a hard limit of 50 000 URLs. With 6 locales + 1 JSON per
-  // preset we get 7 entries per preset, so cap well below that.
-  // Each preset emits 6 locale variants + 1 JSON endpoint = 7 entries. At
-  // 5000 presets that's 35k URLs, leaving ~14k headroom under Google's 50k
-  // sitemap cap for the static + amp-category entries. If we hit this limit
-  // on a production build, we've silently started dropping presets from the
-  // index — that's ops-visible via console.warn + needs a sitemap-index split.
+  // Public preset share pages — one entry per preset (see
+  // SHARE_SITEMAP_LOCALE). Sitemap.xml has a hard limit of 50 000 URLs; at
+  // one entry per preset the cap below leaves ample headroom for the static,
+  // amp and guide entries. If we ever hit the limit on a production build
+  // we've silently started dropping presets from the index — that's
+  // ops-visible via console.warn + needs a sitemap-index split.
   const SITEMAP_PRESET_LIMIT = 5000;
   let presetPages: SitemapEntry[] = [];
   try {
@@ -95,22 +105,15 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
       );
     }
 
-    presetPages = publicPresets.flatMap((preset) => {
-      const entries: SitemapEntry[] = LOCALES.map((locale) => ({
-        url: `${BASE_URL}/${locale}/share/${preset.shareToken}`,
-        lastModified: preset.updatedAt,
-        changeFrequency: 'weekly' as const,
-        priority: 0.6,
-      }));
-      // One locale-less JSON endpoint per preset (API route, not locale-scoped)
-      entries.push({
-        url: `${BASE_URL}/api/share/${preset.shareToken}/json`,
-        lastModified: preset.updatedAt,
-        changeFrequency: 'yearly' as const,
-        priority: 0.3,
-      });
-      return entries;
-    });
+    // The /api/share/<token>/json endpoints used to be listed here. They are
+    // API responses, not pages — 170 URLs of crawl budget spent on something
+    // Google can only index as raw JSON. They are now robots-disallowed.
+    presetPages = publicPresets.map((preset) => ({
+      url: `${BASE_URL}/${SHARE_SITEMAP_LOCALE}/share/${preset.shareToken}`,
+      lastModified: preset.updatedAt,
+      changeFrequency: 'weekly' as const,
+      priority: 0.6,
+    }));
   } catch (err) {
     // Database unavailable during build — skip dynamic pages. Log so ops
     // can see if this is happening in production (was previously silent

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { listAmpCategories } from '@/core/ampCategories';
 import { getActiveAmpSlugs } from '@/lib/ampActivity';
-import { LOCALES, BASE_URL } from '@/lib/hreflang';
+import { LOCALES, localeUrl, DEFAULT_LOCALE } from '@/lib/hreflang';
 import { GUIDE_SLUGS, guideLocales, getGuide } from '@/content/guides';
 
 // Force dynamic generation — the default sitemap.ts output is baked at build
@@ -40,14 +40,14 @@ const STATIC_PAGES: Array<{
 // all seven made /share 1 190 of 1 712 sitemap URLs (70%) while the amp and
 // guide pages that actually earn non-brand clicks got 9. The localized
 // variants stay live, self-canonical and reachable via hreflang.
-const SHARE_SITEMAP_LOCALE = 'en';
+const SHARE_SITEMAP_LOCALE = DEFAULT_LOCALE;
 
 export default async function sitemap(): Promise<SitemapEntry[]> {
   const now = new Date();
 
   const staticPages: SitemapEntry[] = STATIC_PAGES.flatMap((page) =>
     LOCALES.map((locale) => ({
-      url: `${BASE_URL}/${locale}${page.path}`,
+      url: localeUrl(locale, page.path || '/'),
       lastModified: now,
       changeFrequency: page.changeFrequency,
       priority: page.priority,
@@ -72,7 +72,7 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
     .filter((cat) => activeAmpSlugs.has(cat.slug))
     .flatMap((cat) =>
       LOCALES.map((locale) => ({
-        url: `${BASE_URL}/${locale}/amp/${cat.slug}`,
+        url: localeUrl(locale, `/amp/${cat.slug}`),
         lastModified: now,
         changeFrequency: 'weekly' as const,
         priority: 0.7,
@@ -109,7 +109,7 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
     // API responses, not pages — 170 URLs of crawl budget spent on something
     // Google can only index as raw JSON. They are now robots-disallowed.
     presetPages = publicPresets.map((preset) => ({
-      url: `${BASE_URL}/${SHARE_SITEMAP_LOCALE}/share/${preset.shareToken}`,
+      url: localeUrl(SHARE_SITEMAP_LOCALE, `/share/${preset.shareToken}`),
       lastModified: preset.updatedAt,
       changeFrequency: 'weekly' as const,
       priority: 0.6,
@@ -128,7 +128,7 @@ export default async function sitemap(): Promise<SitemapEntry[]> {
   // translation of each slug (others 404 and must stay out of the sitemap).
   const guidePages: SitemapEntry[] = GUIDE_SLUGS.flatMap((slug) =>
     guideLocales(slug).map((locale) => ({
-      url: `${BASE_URL}/${locale}/guides/${slug}`,
+      url: localeUrl(locale, `/guides/${slug}`),
       lastModified: new Date(getGuide(locale, slug)!.updated),
       changeFrequency: 'monthly' as const,
       priority: 0.7,

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -11,6 +11,15 @@ export const routing = defineRouting({
   locales: LOCALES,
   defaultLocale: 'en',
   localeDetection: true,
+  // Off: next-intl would otherwise emit its own `Link: <...>;
+  // rel="alternate"` hreflang set from the middleware, deriving x-default
+  // from the *unprefixed* path. Next.js metadata already emits an HTML
+  // hreflang set (src/lib/hreflang.ts) whose x-default is the /en/ URL, so
+  // every page shipped two contradicting x-default declarations. Google
+  // consolidated on the unprefixed URL — which only 307-redirects and holds
+  // no content (GSC Q2/2026: /help 577 impressions, /en/help 3).
+  // buildAlternates() is the single source of truth for hreflang.
+  alternateLinks: false,
 });
 
 // Typed navigation helpers — import Link, useRouter, usePathname from this module

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -11,6 +11,16 @@ export const routing = defineRouting({
   locales: LOCALES,
   defaultLocale: 'en',
   localeDetection: true,
+  // English is served from the unprefixed path; /en/... only redirects to
+  // it. With the previous 'always' every entry point cost a 307 hop, and
+  // because next-intl issues that redirect as *temporary*, Google kept the
+  // redirecting URL in the index instead of consolidating onto the target.
+  // The index ended up split down the middle — /help 577 impressions vs
+  // /en/help 3, but /en/gallery 308 vs /gallery 10 (GSC Q2/2026). Roughly
+  // 70% of indexed impressions already sit on the unprefixed form, so this
+  // is the shape that costs the least to converge on.
+  // src/lib/hreflang.ts DEFAULT_LOCALE must match defaultLocale above.
+  localePrefix: 'as-needed',
   // Off: next-intl would otherwise emit its own `Link: <...>;
   // rel="alternate"` hreflang set from the middleware, deriving x-default
   // from the *unprefixed* path. Next.js metadata already emits an HTML

--- a/src/lib/hreflang.ts
+++ b/src/lib/hreflang.ts
@@ -27,19 +27,39 @@ export const LOCALE_META: Record<Locale, { flag: string; code: string }> = {
 // so future tests (e.g. sitemap-priority lowering) can read the same set.
 export const BETA_LOCALES = new Set<Locale>(['es', 'fr', 'it', 'pt', 'pt-BR']);
 
+// The default locale. Routing runs with localePrefix 'as-needed', so this
+// one locale is served from the unprefixed path and its /en/... form only
+// redirects there. Keep in sync with defaultLocale in src/i18n/routing.ts —
+// the unit tests assert both ends.
+export const DEFAULT_LOCALE: Locale = 'en';
+
+/**
+ * Absolute URL of `path` in `locale`, using the form the server actually
+ * serves. English is unprefixed; every other locale carries its prefix.
+ *
+ * This distinction is the whole point: handing Google `/en/help` as a
+ * canonical or hreflang target names a URL that only 307-redirects, which
+ * is how the index ended up split between prefixed and unprefixed forms
+ * of the same page.
+ */
+export function localeUrl(locale: Locale, path: string): string {
+  const normalized = path === '/' ? '' : path;
+  const prefix = locale === DEFAULT_LOCALE ? '' : `/${locale}`;
+  return `${BASE_URL}${prefix}${normalized}`;
+}
+
 /**
  * Build an hreflang `languages` map for next.js Metadata.alternates.
  * The path should be the locale-less segment — e.g. "/editor" or
- * "/share/abc123". The helper prefixes every locale + serves x-default
+ * "/share/abc123". The helper covers every locale + serves x-default
  * from English.
  */
 export function buildHreflang(path: string): Record<string, string> {
-  const normalized = path === '/' ? '' : path;
   const out: Record<string, string> = {};
   for (const locale of LOCALES) {
-    out[locale] = `${BASE_URL}/${locale}${normalized}`;
+    out[locale] = localeUrl(locale, path);
   }
-  out['x-default'] = `${BASE_URL}/en${normalized}`;
+  out['x-default'] = localeUrl(DEFAULT_LOCALE, path);
   return out;
 }
 
@@ -51,9 +71,8 @@ export function buildAlternates(
   path: string,
   currentLocale: Locale,
 ): NonNullable<Metadata['alternates']> {
-  const normalized = path === '/' ? '' : path;
   return {
-    canonical: `${BASE_URL}/${currentLocale}${normalized}`,
+    canonical: localeUrl(currentLocale, path),
     languages: buildHreflang(path),
   };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,19 +13,25 @@ const SESSION_COOKIE = 'auth_session';
 // dash (e.g. pt-BR), so escape regex meta-characters.
 const LOCALE_ALT = LOCALES.map((l) => l.replace(/[-]/g, '\\-')).join('|');
 
-const PROTECTED_ROUTE_PATTERN = new RegExp(
-  `^/(?:${LOCALE_ALT})/(?:profile|presets|admin)(?:/|$)`,
+// The locale prefix is optional: routing runs with localePrefix 'as-needed',
+// so the default locale is served from the unprefixed path and /profile is
+// as real a URL as /de/profile. Requiring the prefix here would let the
+// unprefixed form walk past the guard entirely.
+export const PROTECTED_ROUTE_PATTERN = new RegExp(
+  `^(?:/(?:${LOCALE_ALT}))?/(?:profile|presets|admin)(?:/|$)`,
 );
 
-// Extract the locale prefix from a pathname, falling back to en if the path
-// doesn't start with a known locale. Used for login-redirect so a user on
-// /fr/profile without a session gets redirected to /fr/auth/login, not /de.
-const LOCALE_PREFIX_PATTERN = new RegExp(`^/(${LOCALE_ALT})(?=/|$)`);
+// Extract the locale prefix from a pathname. Used for login-redirect so a
+// user on /fr/profile without a session gets redirected to /fr/auth/login,
+// not /de. Returns null for an unprefixed path — that's the default locale,
+// which is served without a prefix, so the login URL stays unprefixed too
+// rather than bouncing through a redirect.
+export const LOCALE_PREFIX_PATTERN = new RegExp(`^/(${LOCALE_ALT})(?=/|$)`);
 
 function loginRedirect(request: NextRequest, pathname: string) {
   const match = LOCALE_PREFIX_PATTERN.exec(pathname);
-  const locale = match ? match[1] : 'en';
-  return NextResponse.redirect(new URL(`/${locale}/auth/login`, request.url));
+  const prefix = match ? `/${match[1]}` : '';
+  return NextResponse.redirect(new URL(`${prefix}/auth/login`, request.url));
 }
 
 export async function middleware(request: NextRequest) {

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -16,7 +16,9 @@ test.describe('Home Page', () => {
   test('Sprache wechseln zu EN', async ({ page }) => {
     await page.goto('/de');
     await page.getByTestId('nav-locale-switcher').click();
-    await expect(page).toHaveURL(/\/en/);
+    // English is the default locale and routing runs with localePrefix
+    // 'as-needed', so switching to EN lands on the unprefixed root.
+    await expect(page).toHaveURL(/\/$/);
     await expect(page.locator('h1')).toContainText('Preset');
   });
 });

--- a/tests/unit/canonical-urls.test.ts
+++ b/tests/unit/canonical-urls.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Under jsdom, next-intl/server resolves to its react-client build, whose
+// getTranslations throws "not supported in Client Components". The pages
+// below only use it for title/description copy — the URLs under test are
+// built independently — so an echo translator is enough to reach them.
+vi.mock('next-intl/server', () => ({
+  getTranslations: async () => Object.assign((key: string) => key, { rich: (key: string) => key }),
+}));
+
+import { generateMetadata as guideMetadata } from '@/app/[locale]/guides/[slug]/page';
+import { generateMetadata as guidesIndexMetadata } from '@/app/[locale]/guides/page';
+import { generateMetadata as changelogMetadata } from '@/app/[locale]/changelog/page';
+import { generateMetadata as helpMetadata } from '@/app/[locale]/help/page';
+import { generateMetadata as playlistsMetadata } from '@/app/[locale]/playlists/page';
+import { GUIDE_SLUGS } from '@/content/guides';
+
+// Under localePrefix 'as-needed' English is served from the unprefixed
+// path and /en/... only 307s there. Any canonical, hreflang or og:url
+// naming a /en/ URL points Google at a redirect instead of a document —
+// which is how the index ended up split across both forms of the same page.
+const EN_PREFIXED = /preset-forge\.com\/en(\/|$)/;
+
+describe('English URLs in metadata are unprefixed', () => {
+  it('guide detail pages', async () => {
+    const slug = GUIDE_SLUGS[0];
+    const meta = await guideMetadata({ params: Promise.resolve({ locale: 'en' as const, slug }) });
+
+    expect(meta.alternates?.canonical).not.toMatch(EN_PREFIXED);
+    expect(meta.alternates?.languages?.['x-default']).not.toMatch(EN_PREFIXED);
+    expect(meta.alternates?.languages?.en).not.toMatch(EN_PREFIXED);
+    expect(meta.openGraph?.url).not.toMatch(EN_PREFIXED);
+  });
+
+  it('keeps other locales prefixed on guide detail pages', async () => {
+    const slug = GUIDE_SLUGS[0];
+    const meta = await guideMetadata({ params: Promise.resolve({ locale: 'de' as const, slug }) });
+    expect(meta.alternates?.canonical).toBe(
+      `https://www.preset-forge.com/de/guides/${slug}`,
+    );
+  });
+
+  it.each([
+    ['guides index', guidesIndexMetadata],
+    ['changelog', changelogMetadata],
+    ['help', helpMetadata],
+    ['playlists', playlistsMetadata],
+  ])('%s', async (_name, generate) => {
+    const meta = await generate({ params: Promise.resolve({ locale: 'en' as const }) });
+
+    expect(meta.alternates?.canonical).not.toMatch(EN_PREFIXED);
+    expect(meta.alternates?.languages?.['x-default']).not.toMatch(EN_PREFIXED);
+    expect(meta.openGraph?.url ?? '').not.toMatch(EN_PREFIXED);
+  });
+});
+
+// The behaviour tests above can only cover pages whose generateMetadata runs
+// without a database. This catches the rest — and any new page — at the
+// source level: interpolating a locale into a URL by hand reintroduces the
+// /en/ bug, so localeUrl() is the only sanctioned way to build one.
+describe('no hand-built locale URLs in src/', () => {
+  function walk(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) return walk(full);
+      return /\.tsx?$/.test(entry) ? [full] : [];
+    });
+  }
+
+  it('never interpolates a locale straight after BASE_URL', () => {
+    const offenders = walk(join(process.cwd(), 'src'))
+      .filter((file) => !file.endsWith(join('lib', 'hreflang.ts')))
+      .flatMap((file) =>
+        readFileSync(file, 'utf8')
+          .split('\n')
+          .map((line, i) => ({ file, line: i + 1, text: line }))
+          .filter(({ text }) => /\$\{BASE_URL\}\/\$\{/.test(text)),
+      )
+      .map(({ file, line, text }) => `${file}:${line} ${text.trim()}`);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/hreflang.test.ts
+++ b/tests/unit/hreflang.test.ts
@@ -1,25 +1,45 @@
 import { describe, it, expect } from 'vitest';
-import { buildHreflang, buildAlternates } from '@/lib/hreflang';
+import { buildHreflang, buildAlternates, localeUrl } from '@/lib/hreflang';
+
+// English is the default locale and routing runs with localePrefix
+// 'as-needed', so English lives at the unprefixed path and /en/... only
+// redirects there. Every URL we hand Google must be the served one.
+describe('localeUrl', () => {
+  it('leaves English unprefixed', () => {
+    expect(localeUrl('en', '/editor')).toBe('https://www.preset-forge.com/editor');
+  });
+
+  it('prefixes every other locale', () => {
+    expect(localeUrl('de', '/editor')).toBe('https://www.preset-forge.com/de/editor');
+    expect(localeUrl('pt-BR', '/editor')).toBe('https://www.preset-forge.com/pt-BR/editor');
+  });
+
+  it('renders the English root as the bare origin', () => {
+    expect(localeUrl('en', '/')).toBe('https://www.preset-forge.com');
+    expect(localeUrl('de', '/')).toBe('https://www.preset-forge.com/de');
+  });
+});
 
 describe('buildHreflang', () => {
   it('returns all 7 locale URLs + x-default for a static path', () => {
     const result = buildHreflang('/editor');
     expect(result).toEqual({
       de: 'https://www.preset-forge.com/de/editor',
-      en: 'https://www.preset-forge.com/en/editor',
+      en: 'https://www.preset-forge.com/editor',
       es: 'https://www.preset-forge.com/es/editor',
       fr: 'https://www.preset-forge.com/fr/editor',
       it: 'https://www.preset-forge.com/it/editor',
       pt: 'https://www.preset-forge.com/pt/editor',
       'pt-BR': 'https://www.preset-forge.com/pt-BR/editor',
-      'x-default': 'https://www.preset-forge.com/en/editor',
+      'x-default': 'https://www.preset-forge.com/editor',
     });
   });
 
   it('handles root path', () => {
     const result = buildHreflang('/');
-    expect(result.en).toBe('https://www.preset-forge.com/en');
-    expect(result['x-default']).toBe('https://www.preset-forge.com/en');
+    expect(result.en).toBe('https://www.preset-forge.com');
+    expect(result['x-default']).toBe('https://www.preset-forge.com');
+    expect(result.de).toBe('https://www.preset-forge.com/de');
   });
 
   it('handles paths with dynamic segments', () => {
@@ -31,15 +51,23 @@ describe('buildHreflang', () => {
 describe('buildAlternates', () => {
   it('returns a full alternates object ready for Metadata', () => {
     const result = buildAlternates('/gallery', 'en');
-    expect(result.canonical).toBe('https://www.preset-forge.com/en/gallery');
+    expect(result.canonical).toBe('https://www.preset-forge.com/gallery');
     expect(result.languages).toHaveProperty('es');
-    expect(result.languages?.['x-default']).toBe('https://www.preset-forge.com/en/gallery');
+    expect(result.languages?.['x-default']).toBe('https://www.preset-forge.com/gallery');
   });
 
   it('accepts the root path "/"', () => {
     const result = buildAlternates('/', 'de');
     expect(result.canonical).toBe('https://www.preset-forge.com/de');
-    expect(result.languages?.en).toBe('https://www.preset-forge.com/en');
+    expect(result.languages?.en).toBe('https://www.preset-forge.com');
+  });
+
+  it('never canonicalises to a URL that only redirects', () => {
+    // /en/... 307s to the unprefixed path under localePrefix 'as-needed'.
+    // A canonical pointing at a redirect is the bug this replaces.
+    for (const path of ['/', '/editor', '/gallery', '/share/abc123']) {
+      expect(buildAlternates(path, 'en').canonical).not.toMatch(/preset-forge\.com\/en(\/|$)/);
+    }
   });
 });
 
@@ -48,7 +76,7 @@ describe('buildHreflang edge cases', () => {
   it('handles deeply nested paths', () => {
     const result = buildHreflang('/amp/marshall-jcm800');
     expect(result.de).toBe('https://www.preset-forge.com/de/amp/marshall-jcm800');
-    expect(result['x-default']).toBe('https://www.preset-forge.com/en/amp/marshall-jcm800');
+    expect(result['x-default']).toBe('https://www.preset-forge.com/amp/marshall-jcm800');
   });
 
   it('does not strip trailing slashes (caller responsibility)', () => {
@@ -56,7 +84,7 @@ describe('buildHreflang edge cases', () => {
     // Pages should normalize paths before calling if they care about
     // canonicalization.
     const result = buildHreflang('/editor/');
-    expect(result.en).toBe('https://www.preset-forge.com/en/editor/');
+    expect(result.en).toBe('https://www.preset-forge.com/editor/');
   });
 
   it('passes query strings through (caller responsibility)', () => {

--- a/tests/unit/middleware-alternate-links.test.ts
+++ b/tests/unit/middleware-alternate-links.test.ts
@@ -26,10 +26,18 @@ describe('intl middleware alternate links', () => {
     expect(link).not.toContain('hreflang');
   });
 
-  it('still redirects an unprefixed path to a locale', async () => {
+  it('serves the unprefixed path directly instead of redirecting', async () => {
+    // localePrefix 'as-needed': English lives here. No hop, and no
+    // temporary redirect for Google to keep in the index.
     const res = await middleware(new NextRequest('https://www.preset-forge.com/help'));
 
+    expect(res?.status).toBe(200);
+  });
+
+  it('redirects the /en/ form onto the unprefixed path', async () => {
+    const res = await middleware(new NextRequest('https://www.preset-forge.com/en/help'));
+
     expect(res?.status).toBe(307);
-    expect(res?.headers.get('location')).toContain('/help');
+    expect(new URL(res!.headers.get('location')!).pathname).toBe('/help');
   });
 });

--- a/tests/unit/middleware-alternate-links.test.ts
+++ b/tests/unit/middleware-alternate-links.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+
+// next-intl's middleware emits its own `Link: <...>; rel="alternate"`
+// hreflang set, and it derives x-default from the *unprefixed* path. Next.js
+// metadata (src/lib/hreflang.ts) emits an HTML hreflang set whose x-default
+// is the /en/ URL. Both were being served on every page:
+//
+//   HTTP  Link: <https://www.preset-forge.com/help>;    hreflang="x-default"
+//   HTML  <link rel="alternate" hrefLang="x-default" href=".../en/help">
+//
+// Two contradicting x-default declarations for one page. Google discards a
+// conflicting hreflang cluster, and the header actively told it the
+// unprefixed URL — which only 307-redirects — was the canonical entry point.
+// GSC confirms which one won: /help 577 impressions, /en/help 3.
+//
+// The HTML metadata is the single source of truth, so the header is off.
+describe('intl middleware alternate links', () => {
+  it('does not emit hreflang Link headers', async () => {
+    const res = await middleware(
+      new NextRequest('https://www.preset-forge.com/en/help'),
+    );
+
+    const link = res?.headers.get('link') ?? '';
+    expect(link).not.toContain('hreflang');
+  });
+
+  it('still redirects an unprefixed path to a locale', async () => {
+    const res = await middleware(new NextRequest('https://www.preset-forge.com/help'));
+
+    expect(res?.status).toBe(307);
+    expect(res?.headers.get('location')).toContain('/help');
+  });
+});

--- a/tests/unit/middleware-auth-guard.test.ts
+++ b/tests/unit/middleware-auth-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+import { LOCALES } from '@/i18n/locales';
+
+const ORIGIN = 'https://www.preset-forge.com';
+
+function request(path: string, opts: { session?: boolean } = {}) {
+  const req = new NextRequest(`${ORIGIN}${path}`);
+  if (opts.session) req.cookies.set('auth_session', 'not-validated-here');
+  return req;
+}
+
+function locationOf(res: Response | undefined) {
+  const loc = res?.headers.get('location');
+  return loc ? new URL(loc, ORIGIN).pathname : null;
+}
+
+// Under localePrefix 'as-needed' the default locale is served from the
+// unprefixed path, so /profile, /presets and /admin are live URLs — not
+// only /en/profile. The cookie-presence guard has to cover both shapes or
+// the unprefixed form walks straight past it.
+describe('auth guard covers unprefixed default-locale routes', () => {
+  it.each(['/profile', '/presets', '/admin'])(
+    'redirects %s to login when no session cookie is present',
+    async (path) => {
+      const res = await middleware(request(path));
+      expect(locationOf(res)).toBe('/auth/login');
+    },
+  );
+
+  it('redirects nested unprefixed protected routes too', async () => {
+    expect(locationOf(await middleware(request('/admin/users')))).toBe('/auth/login');
+    expect(locationOf(await middleware(request('/profile/edit')))).toBe('/auth/login');
+  });
+
+  it('keeps the visitor in their locale when the path is prefixed', async () => {
+    expect(locationOf(await middleware(request('/de/profile')))).toBe('/de/auth/login');
+    expect(locationOf(await middleware(request('/pt-BR/admin')))).toBe('/pt-BR/auth/login');
+  });
+
+  it('guards every locale, prefixed and unprefixed alike', async () => {
+    for (const locale of LOCALES) {
+      const res = await middleware(request(`/${locale}/profile`));
+      // Every locale must end up at *some* login page rather than the
+      // profile itself. pt-BR must not partial-match as pt.
+      expect(locationOf(res)).toMatch(/\/auth\/login$/);
+    }
+  });
+
+  it('does not intercept public routes', async () => {
+    expect(locationOf(await middleware(request('/gallery')))).not.toBe('/auth/login');
+    expect(locationOf(await middleware(request('/de/gallery')))).not.toBe('/auth/login');
+  });
+
+  it('lets a request through when the session cookie is present', async () => {
+    // The cookie is only checked for presence here — edge runtime can't
+    // reach Prisma. Each page revalidates the session server-side.
+    const res = await middleware(request('/profile', { session: true }));
+    expect(locationOf(res)).not.toBe('/auth/login');
+  });
+});

--- a/tests/unit/seo-noindex.test.ts
+++ b/tests/unit/seo-noindex.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { generateMetadata as changelogMetadata } from '@/app/[locale]/changelog/page';
+import { generateMetadata as legalMetadata } from '@/app/[locale]/legal/page';
+
+// Pages that exist for humans but must never compete for search impressions.
+// Both were measured in Google Search Console over 2026-04-30..2026-07-29:
+//   /changelog  180 impressions →  1 click (CTR 0.56%, worst on the site)
+//   /legal       21 impressions →  0 clicks
+// They rank for long-tail queries they cannot answer, which drags the
+// site-wide CTR and average position down without ever earning a visit.
+describe('noindex pages', () => {
+  it('marks /changelog noindex while keeping its links crawlable', async () => {
+    const meta = await changelogMetadata({ params: Promise.resolve({ locale: 'en' as const }) });
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('marks /legal noindex while keeping its links crawlable', async () => {
+    const meta = await legalMetadata({ params: Promise.resolve({ locale: 'en' }) });
+    expect(meta.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('keeps the canonical + hreflang block on noindex pages', async () => {
+    // noindex removes the page from the index; it does not make duplicate
+    // locale variants of it stop existing. The hreflang cluster stays so the
+    // seven variants are still understood as one page.
+    const meta = await changelogMetadata({ params: Promise.resolve({ locale: 'de' as const }) });
+    expect(meta.alternates?.canonical).toBe('https://www.preset-forge.com/de/changelog');
+  });
+});
+
+describe('robots.txt', () => {
+  const robots = readFileSync(join(process.cwd(), 'public', 'robots.txt'), 'utf8');
+
+  it('disallows /api/ — API routes are responses, not pages', () => {
+    expect(robots).toMatch(/^Disallow: \/api\//m);
+  });
+
+  it('still allows the rest of the site and points at the sitemap', () => {
+    expect(robots).toMatch(/^Allow: \/$/m);
+    expect(robots).toContain('Sitemap: https://www.preset-forge.com/sitemap.xml');
+  });
+});

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -23,26 +23,34 @@ beforeEach(() => {
 });
 
 describe('sitemap', () => {
-  it('emits HTML + JSON URLs for each public preset', async () => {
+  it('emits only the x-default (en) share URL per public preset', async () => {
     (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       { shareToken: 'abc', updatedAt: new Date('2026-04-01') },
     ]);
 
     const entries = await sitemap();
     const urls = entries.map((e) => e.url);
-    // All 7 locale variants
-    expect(urls).toContain('https://www.preset-forge.com/de/share/abc');
     expect(urls).toContain('https://www.preset-forge.com/en/share/abc');
-    expect(urls).toContain('https://www.preset-forge.com/es/share/abc');
-    expect(urls).toContain('https://www.preset-forge.com/fr/share/abc');
-    expect(urls).toContain('https://www.preset-forge.com/it/share/abc');
-    expect(urls).toContain('https://www.preset-forge.com/pt/share/abc');
-    expect(urls).toContain('https://www.preset-forge.com/pt-BR/share/abc');
-    // Plus the JSON endpoint
-    expect(urls).toContain('https://www.preset-forge.com/api/share/abc/json');
+    // The other six locales are near-duplicates — the preset name, amp and
+    // parameter values are identical, only the surrounding chrome is
+    // translated. They stay reachable and self-canonical, but listing all
+    // seven made share pages 70% of the sitemap and starved the amp and
+    // guide pages of crawl budget. Google finds the rest via hreflang.
+    for (const locale of ['de', 'es', 'fr', 'it', 'pt', 'pt-BR']) {
+      expect(urls).not.toContain(`https://www.preset-forge.com/${locale}/share/abc`);
+    }
   });
 
-  it('emits eight entries per preset (7 locale HTML + 1 JSON)', async () => {
+  it('emits no /api/ URLs — the sitemap is for pages, not JSON endpoints', async () => {
+    (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { shareToken: 'abc', updatedAt: new Date('2026-04-01') },
+    ]);
+
+    const entries = await sitemap();
+    expect(entries.filter((e) => e.url.includes('/api/'))).toHaveLength(0);
+  });
+
+  it('emits exactly one entry per preset', async () => {
     (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       Array.from({ length: 10 }, (_, i) => ({
         shareToken: `tok${i}`,
@@ -52,11 +60,16 @@ describe('sitemap', () => {
 
     const entries = await sitemap();
     const presetEntries = entries.filter(
-      (e) =>
-        (e.url.includes('/share/') || e.url.includes('/api/share/')) &&
-        !e.url.includes('/amp/'),
+      (e) => e.url.includes('/share/') && !e.url.includes('/amp/'),
     );
-    expect(presetEntries).toHaveLength(80);
+    expect(presetEntries).toHaveLength(10);
+  });
+
+  it('omits /changelog — it is noindex and must not be advertised for crawl', async () => {
+    (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+    const entries = await sitemap();
+    expect(entries.filter((e) => e.url.includes('/changelog'))).toHaveLength(0);
   });
 
   it('emits amp category URLs for all 7 locales (only for active slugs)', async () => {

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/ampActivity', () => ({
 import sitemap from '@/app/sitemap';
 import { prisma } from '@/lib/prisma';
 import { getActiveAmpSlugs } from '@/lib/ampActivity';
+import { LOCALES, localeUrl } from '@/lib/hreflang';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -23,14 +24,35 @@ beforeEach(() => {
 });
 
 describe('sitemap', () => {
-  it('emits only the x-default (en) share URL per public preset', async () => {
+  it('never lists a /en/ URL — those only redirect under as-needed prefixing', async () => {
+    (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { shareToken: 'abc', updatedAt: new Date('2026-04-01') },
+    ]);
+    (getActiveAmpSlugs as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Set(['fender-65-twin-reverb']),
+    );
+
+    const entries = await sitemap();
+    const prefixed = entries.filter((e) => /preset-forge\.com\/en(\/|$)/.test(e.url));
+    expect(prefixed).toEqual([]);
+  });
+
+  it('lists the unprefixed English home page', async () => {
+    (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+    const urls = (await sitemap()).map((e) => e.url);
+    expect(urls).toContain('https://www.preset-forge.com');
+    expect(urls).toContain('https://www.preset-forge.com/de');
+  });
+
+  it('emits only the x-default (English) share URL per public preset', async () => {
     (prisma.preset.findMany as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       { shareToken: 'abc', updatedAt: new Date('2026-04-01') },
     ]);
 
     const entries = await sitemap();
     const urls = entries.map((e) => e.url);
-    expect(urls).toContain('https://www.preset-forge.com/en/share/abc');
+    expect(urls).toContain('https://www.preset-forge.com/share/abc');
     // The other six locales are near-duplicates — the preset name, amp and
     // parameter values are identical, only the surrounding chrome is
     // translated. They stay reachable and self-canonical, but listing all
@@ -79,8 +101,10 @@ describe('sitemap', () => {
     (getActiveAmpSlugs as ReturnType<typeof vi.fn>).mockResolvedValueOnce(activeSlugs);
 
     const entries = await sitemap();
-    const perLocale = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pt-BR'].map((l) =>
-      entries.filter((e) => e.url.match(new RegExp(`/${l}/amp/[a-z0-9-]+$`))),
+    // English is unprefixed under localePrefix 'as-needed', so match on the
+    // URL each locale is actually served from rather than assuming a prefix.
+    const perLocale = LOCALES.map((l) =>
+      entries.filter((e) => e.url.startsWith(localeUrl(l, '/amp/'))),
     );
 
     // Every locale should have one URL per active slug that exists in the

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,11 +8,22 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['tests/unit/setup.ts'],
+    // next-intl ships ESM that imports 'next/server' / 'next/navigation'
+    // extensionless. Inlining it routes those through the resolve.alias
+    // below instead of node's bare-specifier resolution, which lets tests
+    // import src/middleware.ts and locale-aware page modules.
+    server: { deps: { inline: ['next-intl'] } },
     include: ['tests/unit/**/*.test.ts', 'tests/unit/**/*.test.tsx'],
   },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // next-intl's ESM build imports 'next/server' and 'next/navigation'
+      // without a file extension, which vitest's ESM loader can't resolve.
+      // Point both at the real files so tests can import the middleware and
+      // any page module that pulls in @/i18n/routing.
+      'next/server': path.resolve(__dirname, './node_modules/next/server.js'),
+      'next/navigation': path.resolve(__dirname, './node_modules/next/navigation.js'),
     },
   },
 });


### PR DESCRIPTION
## Why

Google Search Console, 2026-04-30..2026-07-29:

| Monat | Klicks | Impr. | CTR | Ø Pos |
|---|---|---|---|---|
| Mai | 79 | 360 | 21,9 % | 6,02 |
| Jun | 97 | 736 | 13,2 % | 5,91 |
| Jul | 123 | 979 | 12,6 % | 7,28 |

Impressions +172 %, clicks +56 %, CTR halved, position worse. The growth came from more thin URLs entering the index, not from better rankings.

Four causes, all fixed here. Both commits ship together on purpose — splitting them would make Google migrate the index twice in a row.

---

### 1 — Two contradicting hreflang sets (root cause)

next-intl's middleware emitted its own `Link:` hreflang set deriving `x-default` from the *unprefixed* path, while the HTML metadata declared `x-default` as the `/en/` URL:

```
HTTP  Link: <https://www.preset-forge.com/help>;    hreflang="x-default"
HTML  <link rel="alternate" hrefLang="x-default" href=".../en/help">
```

Google discards a conflicting cluster. `alternateLinks: false` makes `src/lib/hreflang.ts` the single source of truth.

### 2 — `localePrefix: 'always'` → `'as-needed'`

Every entry point cost a 307 hop. next-intl issues that redirect as *temporary*, so Google kept the source URL rather than consolidating onto the target — and the index split down the middle of each page:

| unprefixed | | prefixed | |
|---|---|---|---|
| `/help` | 577 | `/en/help` | 3 |
| `/` | 775 | `/en` | 10 |
| `/gallery` | 10 | `/en/gallery` | **308** |

~70 % of indexed impressions already sit unprefixed, so that's the shape that costs least to converge on: **~510 impressions migrate instead of ~1455.**

**Security-relevant:** under `as-needed`, `/profile`, `/presets` and `/admin` are live URLs in their own right. `PROTECTED_ROUTE_PATTERN` required a locale prefix and would have let the unprefixed form walk past the cookie check. The prefix is now optional in both middleware patterns; `loginRedirect` keeps an unprefixed request unprefixed. The RED run of `middleware-auth-guard.test.ts` confirmed the unprefixed paths were reaching the page.

`localeUrl(locale, path)` is now the only sanctioned way to build a public URL. Every canonical, hreflang entry, `og:url` and JSON-LD `@id` that interpolated a locale by hand goes through it — including the guide detail pages, which built their own hreflang map with `x-default` → `/en/guides/<slug>`.

### 3 — `/changelog` + `/legal` noindex

`/changelog`: 180 impressions, 1 click (CTR 0.56 %, worst on the site) — 2 139 indexable words of release notes ranking for long-tail queries they can't answer. `/legal`: 21 impressions, 0 clicks. Both `index:false, follow:true`; `/changelog` also out of the sitemap.

### 4 — Sitemap: 1 712 → ~530 URLs

- 1 190 share URLs (170 presets × 7 locales) → **one per preset**. The seven variants carry identical preset data with only chrome translated. They stay live, self-canonical and reachable via hreflang.
- 170 `/api/share/<token>/json` URLs removed — API responses, not pages. `/api/` is now robots-disallowed.

Crawl budget goes to the amp and guide pages that actually earn non-brand clicks (they had 9 sitemap URLs between them).

---

## Tests

New: `middleware-alternate-links`, `middleware-auth-guard`, `canonical-urls`, `seo-noindex`. Rewritten: `sitemap`, `hreflang`. **799 unit tests pass**, lint + typecheck + build green.

`vitest.config.ts` inlines next-intl and aliases `next/server` / `next/navigation` — without that the middleware could only be verified against production.

## Verified against a production build

```
/help        200, canonical https://www.preset-forge.com/help, no hreflang Link header
/en/help     307 → /help
/de/help     200, canonical .../de/help, one consistent hreflang set
/profile     307 → /auth/login       (no session cookie)
/de/profile  307 → /de/auth/login
/admin       307 → /auth/login
/changelog   meta robots noindex, follow
sitemap.xml  0 /en/ URLs, 0 /api/ URLs, 0 /changelog URLs
```

## Expected aftermath

GSC will show indexed-URL churn for 2–4 weeks as `/en/gallery` and `/en/amp/*` fold into their unprefixed forms. Impressions should *drop* as the thin share and changelog URLs leave the index — that's the intended outcome; watch clicks and average position, not impression count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)