### PR TITLE
fix(i18n): add the missing home.uploadCta key in all 7 locales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ npm run test                     # Vitest Unit-Tests
 npm run test:e2e                 # Playwright E2E (App muss laufen + Garage + DB)
 npm run lint                     # ESLint
 npm run build                    # Production Build
+npx next start -p 3123           # Prod-Build lokal servieren — Header, Canonicals, Redirects prüfen ohne Docker
 npm run ci                       # Lokale CI: lint + typecheck + test + build (ersetzt GH Actions)
 bash scripts/local-ci.sh lint typecheck   # Einzelne Stages
 npx vitest run path/test.ts -t "pattern"  # Single-File + Test-Name-Grep (schnelles TDD-Iterate)
@@ -78,6 +79,9 @@ src/
 - Nie `next/link` oder `next/navigation` direkt importieren (Ausnahme: `redirect()` in Server Components)
 - Alle UI-Strings über `useTranslations()` / `getTranslations()` (kein Hardcoding)
 - Translations in `messages/{de,en,es,fr,it,pt,pt-BR}.json` — 7 Locales, Key-Parität per Unit-Test erzwungen
+- `messages-parity` prüft nur Locales gegeneinander — ein überall fehlender Key sähe wie perfekte Parität aus; `messages-usage` schließt die Lücke und prüft jeden literalen `t('…')`-Aufruf in `src/` gegen `en.json`
+- `localePrefix: 'as-needed'` — EN läuft unpräfigiert (`/help`), `/en/help` 307t dorthin; alle anderen Locales behalten ihr Präfix
+- Public URLs immer über `localeUrl(locale, path)` aus `@/lib/hreflang` — kennt die EN-Ausnahme; `tests/unit/canonical-urls.test.ts` erzwingt es
 - Hreflang: `src/lib/hreflang.ts` mit `buildAlternates(path, locale)` — nie inline schreiben
 
 ---
@@ -148,3 +152,6 @@ src/
 - `@import url('https://fonts.googleapis.com/...')` oder andere externe Font-CDNs — Fonts laufen via `next/font/google` (Build-Time self-host); externe Imports brechen DSGVO-Compliance (LG München 3 O 17493/20)
 - Matomo-Script ohne `_paq.push(["disableCookies"])` + `_paq.push(["setDoNotTrack", true])` deployen — beide Flags MÜSSEN vor `trackPageView` stehen, sonst widerspricht der Code der Datenschutzerklärung
 - `youtube.com/embed/...` für Iframes verwenden — IMMER `youtube-nocookie.com/embed/...` (CSP `frame-src` erlaubt nur die nocookie-Domain)
+- `${BASE_URL}/${locale}/...` von Hand bauen — unter `as-needed` zeigt der Canonical dann auf einen Redirect statt auf ein Dokument; immer `localeUrl(locale, path)`
+- `alternateLinks` in `defineRouting` wieder aktivieren — next-intl setzt dann einen `Link:`-hreflang-Header, dessen x-default der HTML-Metadata widerspricht; Google verwirft das ganze Cluster
+- Locale-Präfix in `PROTECTED_ROUTE_PATTERN` (`middleware.ts`) zur Pflicht machen — unter `as-needed` sind `/profile`, `/presets`, `/admin` eigenständige URLs und liefen sonst am Auth-Guard vorbei

--- a/messages/de.json
+++ b/messages/de.json
@@ -115,7 +115,8 @@
       "recentComments": "Aktuelle Kommentare",
       "openPreset": "Preset öffnen →",
       "noFeatured": "Noch kein Featured-Preset"
-    }
+    },
+    "uploadCta": "Preset von Festplatte laden"
   },
   "footer": {
     "disclaimer": "Preset Forge — Inoffizielles Tool. Nicht von Valeton.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -115,7 +115,8 @@
       "recentComments": "Recent comments",
       "openPreset": "Open preset →",
       "noFeatured": "No featured preset yet"
-    }
+    },
+    "uploadCta": "Load preset from disk"
   },
   "footer": {
     "disclaimer": "Preset Forge — Unofficial tool. Not affiliated with Valeton.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -115,7 +115,8 @@
       "recentComments": "Comentarios recientes",
       "openPreset": "Abrir preset →",
       "noFeatured": "Aún no hay preset destacado"
-    }
+    },
+    "uploadCta": "Cargar preset desde disco"
   },
   "footer": {
     "disclaimer": "Preset Forge — Herramienta no oficial. No afiliada con Valeton.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -115,7 +115,8 @@
       "recentComments": "Commentaires récents",
       "openPreset": "Ouvrir le preset →",
       "noFeatured": "Aucun preset en vedette pour l'instant"
-    }
+    },
+    "uploadCta": "Charger le preset depuis le disque"
   },
   "footer": {
     "disclaimer": "Preset Forge — Outil non officiel. Non affilié à Valeton.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -115,7 +115,8 @@
       "recentComments": "Commenti recenti",
       "openPreset": "Apri preset →",
       "noFeatured": "Nessun preset in primo piano"
-    }
+    },
+    "uploadCta": "Carica preset dal disco"
   },
   "footer": {
     "disclaimer": "Preset Forge — Strumento non ufficiale. Non affiliato a Valeton.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -115,7 +115,8 @@
       "recentComments": "Comentários recentes",
       "openPreset": "Abrir preset →",
       "noFeatured": "Ainda sem preset em destaque"
-    }
+    },
+    "uploadCta": "Carregar preset do disco"
   },
   "footer": {
     "disclaimer": "Preset Forge — Ferramenta não oficial. Não afiliada à Valeton.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -115,7 +115,8 @@
       "recentComments": "Comentários recentes",
       "openPreset": "Abrir preset →",
       "noFeatured": "Ainda sem preset em destaque"
-    }
+    },
+    "uploadCta": "Carregar preset do disco"
   },
   "footer": {
     "disclaimer": "Preset Forge — Ferramenta não oficial. Não afiliada à Valeton.",

--- a/tests/unit/messages-usage.test.ts
+++ b/tests/unit/messages-usage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// messages-parity.test.ts compares every locale against en.json, so it only
+// catches a key that some locales have and others lack. A key that no file
+// has at all — because a component asked for one that was never written —
+// looks like perfect parity and ships. `home.uploadCta` did exactly that
+// from cd70c71 until this test, throwing MISSING_MESSAGE on every render of
+// the editor page in production.
+//
+// This walks the other direction: from the t('...') call sites in src/ back
+// to en.json.
+
+const NAMESPACE_BINDING =
+  /(?:const|let)\s+(\w+)\s*=\s*(?:await\s+)?(?:useTranslations|getTranslations)\s*\(\s*(?:\{[^}]*namespace:\s*)?['"`]([\w.]+)['"`]/g;
+// t('some.key') — literal single-quoted keys only. Template literals and
+// computed keys are resolved at runtime and can't be checked statically.
+const CALL = (varName: string) =>
+  new RegExp(`\\b${varName}\\s*\\(\\s*['"]([\\w.]+)['"]`, 'g');
+
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir).flatMap((entry) => {
+    const full = path.join(dir, entry);
+    if (fs.statSync(full).isDirectory()) return sourceFiles(full);
+    return /\.tsx?$/.test(entry) ? [full] : [];
+  });
+}
+
+function hasKey(obj: unknown, dotted: string): boolean {
+  let cur: unknown = obj;
+  for (const part of dotted.split('.')) {
+    if (cur === null || typeof cur !== 'object') return false;
+    if (!(part in (cur as Record<string, unknown>))) return false;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return true;
+}
+
+describe('translation keys used in src/ exist in en.json', () => {
+  const en = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'messages', 'en.json'), 'utf-8'),
+  );
+
+  it('every literal t(...) call resolves to a real key', () => {
+    const missing: string[] = [];
+
+    for (const file of sourceFiles(path.join(process.cwd(), 'src'))) {
+      const src = fs.readFileSync(file, 'utf-8');
+
+      for (const [, varName, namespace] of src.matchAll(NAMESPACE_BINDING)) {
+        for (const [, key] of src.matchAll(CALL(varName))) {
+          const dotted = `${namespace}.${key}`;
+          if (!hasKey(en, dotted)) {
+            missing.push(`${path.relative(process.cwd(), file)}: ${dotted}`);
+          }
+        }
+      }
+    }
+
+    expect([...new Set(missing)].sort()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Bug

`FileUpload.tsx:49,56` has called `t('uploadCta')` since `cd70c71` (March) for both the drop zone's visible label and its `aria-label` — but the key was never written to any `messages/*.json`.

Found in the production logs during today's SEO deploy smoke test:

```
Error: MISSING_MESSAGE: home.uploadCta (en)
    at g (.next/server/app/[locale]/editor/page.js:1:10381)
```

Two consequences: an error on every render of the editor page, and a drop zone whose accessible name was the raw key path — a WCAG regression on the site's primary interaction.

## Why the existing test missed it

`messages-parity.test.ts` compares every locale against `en.json`. A key that **no** file has looks like perfect parity.

`messages-usage.test.ts` (new) walks the other direction: it resolves each `useTranslations` / `getTranslations` namespace binding in `src/` back to the variable it was assigned to, then checks every literal `t('...')` call against `en.json`. Template literals and computed keys are skipped — they resolve at runtime and can't be checked statically.

The RED run found exactly one offender across the whole codebase:

```
src/components/FileUpload.tsx: home.uploadCta
```

## The copy is not new

`help.gettingStartedLoad` already quotes this button by name in all seven locales, so the CTA now matches the documentation that promised it:

| | |
|---|---|
| de | Preset von Festplatte laden |
| en | Load preset from disk |
| es | Cargar preset desde disco |
| fr | Charger le preset depuis le disque |
| it | Carica preset dal disco |
| pt / pt-BR | Carregar preset do disco |

Also adds the missing trailing newline to the seven message files.

## Tests

800 unit tests pass, lint + typecheck + build green.

CLAUDE.md documents the parity/usage split so the gap isn't reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)