### PR TITLE
docs(claude-md): note that deploy pulls master, and the boot-time stream error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ bash scripts/local-ci.sh lint typecheck   # Einzelne Stages
 npx vitest run path/test.ts -t "pattern"  # Single-File + Test-Name-Grep (schnelles TDD-Iterate)
 ```
 
-**Prod-Deploy:** `ssh musikersuche@musikersuche.org` → `cd /opt/gp200editor && bash scripts/deploy-update.sh`
+**Prod-Deploy:** `ssh musikersuche@musikersuche.org` → `cd /opt/gp200editor && bash scripts/deploy-update.sh` — Script macht `git pull` auf **master** (prod ist dort ausgecheckt), PR also vorher mergen
 **Prod-SQL:** `source .env.prod && docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"`
 
 ---
@@ -155,3 +155,4 @@ src/
 - `${BASE_URL}/${locale}/...` von Hand bauen — unter `as-needed` zeigt der Canonical dann auf einen Redirect statt auf ein Dokument; immer `localeUrl(locale, path)`
 - `alternateLinks` in `defineRouting` wieder aktivieren — next-intl setzt dann einen `Link:`-hreflang-Header, dessen x-default der HTML-Metadata widerspricht; Google verwirft das ganze Cluster
 - Locale-Präfix in `PROTECTED_ROUTE_PATTERN` (`middleware.ts`) zur Pflicht machen — unter `as-needed` sind `/profile`, `/presets`, `/admin` eigenständige URLs und liefen sonst am Auth-Guard vorbei
+- `TypeError: controller[kState].transformAlgorithm is not a function` im App-Log nachjagen — erscheint 1–2× direkt nach Container-Start (Health-Check-Warmup) und reproduziert sich unter Last nicht, auch nicht über die S3-Streaming-Endpoints


### PR DESCRIPTION
Two things that cost time during yesterday's SEO deploys (#95, #96).

**`deploy-update.sh` pulls master.** The script runs `git pull` in `/opt/gp200editor`, which is checked out on `master` — verified on the box. There is no branch deploy, so a PR has to be merged first. Stating it next to the command beats leaving it to be discovered by reading the script.

**The boot-time stream error is noise.** `TypeError: controller[kState].transformAlgorithm is not a function` appears 1–2× in the app log immediately after every container start, during the deploy script's own health-check warmup. Chased twice — across `/api/share/<token>/download`, `/api/share/<token>/json`, `/api/gallery` and share pages in all 7 locales — and it never reproduced under load. Documented so the next smoke test doesn't chase it a third time.

Docs only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)