### PR TITLE
feat(ui): make support CTA prominent in nav and footer

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menü",
     "discordTitle": "Feedback & Community",
-    "helpAria": "Hilfe"
+    "helpAria": "Hilfe",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Inoffizielles Tool. Nicht von Valeton.",
     "legal": "Impressum & Datenschutz",
     "poweredBy": "powered by",
-    "guides": "Anleitungen"
+    "guides": "Anleitungen",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Preset bearbeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menu",
     "discordTitle": "Feedback & Community",
-    "helpAria": "Help"
+    "helpAria": "Help",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Unofficial tool. Not affiliated with Valeton.",
     "legal": "Legal & Privacy",
     "poweredBy": "powered by",
-    "guides": "Guides"
+    "guides": "Guides",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Edit Preset",

--- a/messages/es.json
+++ b/messages/es.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menú",
     "discordTitle": "Comentarios & Comunidad",
-    "helpAria": "Ayuda"
+    "helpAria": "Ayuda",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Herramienta no oficial. No afiliada con Valeton.",
     "legal": "Aviso legal y privacidad",
     "poweredBy": "powered by",
-    "guides": "Guías"
+    "guides": "Guías",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Editar Preset",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menu",
     "discordTitle": "Feedback & Communauté",
-    "helpAria": "Aide"
+    "helpAria": "Aide",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Outil non officiel. Non affilié à Valeton.",
     "legal": "Mentions légales & Confidentialité",
     "poweredBy": "propulsé par",
-    "guides": "Guides"
+    "guides": "Guides",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Modifier le preset",

--- a/messages/it.json
+++ b/messages/it.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menu",
     "discordTitle": "Feedback & Community",
-    "helpAria": "Aiuto"
+    "helpAria": "Aiuto",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Strumento non ufficiale. Non affiliato a Valeton.",
     "legal": "Note legali e Privacy",
     "poweredBy": "powered by",
-    "guides": "Guide"
+    "guides": "Guide",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Modifica Preset",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menu",
     "discordTitle": "Feedback & Comunidade",
-    "helpAria": "Ajuda"
+    "helpAria": "Ajuda",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Ferramenta não oficial. Não afiliada à Valeton.",
     "legal": "Aviso Legal & Privacidade",
     "poweredBy": "desenvolvido com",
-    "guides": "Guias"
+    "guides": "Guias",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Editar Preset",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -15,7 +15,8 @@
     "changelog": "Changelog",
     "menuAria": "Menu",
     "discordTitle": "Feedback & Comunidade",
-    "helpAria": "Ajuda"
+    "helpAria": "Ajuda",
+    "supportCta": "Buy me a guitar"
   },
   "home": {
     "hero": {
@@ -122,7 +123,8 @@
     "disclaimer": "Preset Forge — Ferramenta não oficial. Não afiliada à Valeton.",
     "legal": "Aviso Legal & Privacidade",
     "poweredBy": "desenvolvido com",
-    "guides": "Guias"
+    "guides": "Guias",
+    "supportCta": "Buy me a guitar"
   },
   "editor": {
     "title": "Editar Preset",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,10 +6,27 @@ export function Footer() {
   return (
     <footer
       role="contentinfo"
-      className="px-6 py-3 text-xs text-center"
+      className="px-6 py-4 text-xs text-center"
       style={{ color: 'var(--text-muted)', borderTop: '1px solid var(--border-subtle)', background: 'var(--bg-surface)' }}
       data-testid="footer"
     >
+      <div className="mb-3">
+        <a
+          href="https://buymeacoffee.com/phash"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="footer-support-cta"
+          className="inline-flex items-center gap-2 font-mono-display text-sm font-bold px-5 py-2 rounded transition-all bg-[rgba(255,221,51,0.08)] hover:bg-[rgba(255,221,51,0.2)] hover:shadow-[0_0_12px_rgba(255,221,51,0.4)]"
+          style={{
+            border: '1px solid rgba(255,221,51,0.4)',
+            color: '#ffdd33',
+            textDecoration: 'none',
+          }}
+        >
+          <span aria-hidden="true">🎸</span>
+          {t('supportCta')}
+        </a>
+      </div>
       {t('disclaimer')}
       <span style={{ margin: '0 8px' }}>·</span>
       <Link
@@ -41,15 +58,6 @@ export function Footer() {
         style={{ color: 'var(--text-muted)', textDecoration: 'none' }}
       >
         Contact
-      </a>
-      <span style={{ margin: '0 8px' }}>·</span>
-      <a
-        href="https://buymeacoffee.com/phash"
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: '#ffdd33', textDecoration: 'underline' }}
-      >
-        ☕ Buy me a coffee
       </a>
     </footer>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -66,6 +66,22 @@ export function Navbar() {
           FW 1.8.0
         </span>
       </div>
+      {/* Support CTA — sits centered between logo and links via justify-between; in-flow, so it can never overlap the nav links */}
+      <a
+        href="https://buymeacoffee.com/phash"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="nav-support-cta"
+        className="hidden xl:flex items-center gap-2 font-mono-display text-sm font-bold px-4 py-1.5 rounded transition-all bg-[rgba(255,221,51,0.08)] hover:bg-[rgba(255,221,51,0.2)] hover:shadow-[0_0_12px_rgba(255,221,51,0.4)]"
+        style={{
+          border: '1px solid rgba(255,221,51,0.4)',
+          color: '#ffdd33',
+          textDecoration: 'none',
+        }}
+      >
+        <span aria-hidden="true">🎸</span>
+        {t('supportCta')}
+      </a>
       {/* Hamburger button — mobile only */}
       <button
         className="md:hidden flex flex-col gap-1 p-1"
@@ -152,14 +168,15 @@ export function Navbar() {
           href="https://buymeacoffee.com/phash"
           target="_blank"
           rel="noopener noreferrer"
-          className="font-mono-display text-xs px-2.5 py-1 rounded transition-all bg-[rgba(255,221,51,0.08)] hover:bg-[rgba(255,221,51,0.2)] hover:shadow-[0_0_8px_rgba(255,221,51,0.3)]"
+          title={t('supportCta')}
+          className="xl:hidden font-mono-display text-xs px-2.5 py-1 rounded transition-all bg-[rgba(255,221,51,0.08)] hover:bg-[rgba(255,221,51,0.2)] hover:shadow-[0_0_8px_rgba(255,221,51,0.3)]"
           style={{
             border: '1px solid rgba(255,221,51,0.3)',
             color: '#ffdd33',
             textDecoration: 'none',
           }}
         >
-          ☕
+          🎸
         </a>
         <LocaleSwitcher />
         {role === 'ADMIN' && (
@@ -251,6 +268,19 @@ export function Navbar() {
               {tAuth('login')}
             </Link>
           )}
+          <a
+            href="https://buymeacoffee.com/phash"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono-display text-sm font-bold px-3 py-2 rounded text-center bg-[rgba(255,221,51,0.08)]"
+            style={{
+              border: '1px solid rgba(255,221,51,0.4)',
+              color: '#ffdd33',
+              textDecoration: 'none',
+            }}
+          >
+            <span aria-hidden="true">🎸</span> {t('supportCta')}
+          </a>
           <div
             className="flex gap-2 items-center pt-3 flex-wrap"
             style={{ borderTop: '1px solid var(--border-subtle)' }}


### PR DESCRIPTION
Buy-me-a-coffee link was a bare ☕ emoji in the navbar and small print in the footer.

- Navbar: spelled-out **🎸 Buy me a guitar** LED-style button, in-flow centered between logo and nav links (≥xl); compact 🎸 icon button below xl
- Mobile menu: new CTA entry (was missing entirely)
- Footer: own prominent button line above the small print, old inline link removed
- Text via i18n key `supportCta` (nav + footer) in all 7 locales
- Verified via screenshots at 1280/1366/1440/390, logged-in and logged-out — no nav overlap in any state

Local CI green (lint, typecheck, tests incl. messages-parity/usage, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)